### PR TITLE
HTTPS link for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "stan"]
 	path = stan
-	url = git@github.com:stan-dev/stan.git
+	url = https://github.com/stan-dev/stan


### PR DESCRIPTION
Currently, users without an SSH key registered on GitHub will fail to clone this repository:

```
# git clone --recursive https://github.com/jrnold/stan-language-definitions.git
Cloning into 'stan-language-definitions'...
remote: Counting objects: 56, done.
remote: Total 56 (delta 0), reused 0 (delta 0), pack-reused 56
Unpacking objects: 100% (56/56), done.
Checking connectivity... done.
Submodule 'stan' (git@github.com:stan-dev/stan.git) registered for path 'stan'
Cloning into 'stan'...
Warning: Permanently added the RSA host key for IP address '192.30.252.129' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:stan-dev/stan.git' into submodule path 'stan' failed
```

This is happening because of the SSH link for the submodule. This pull request changes it to use an HTTPS link instead.
