### PR TITLE
Fix typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,20 @@
+# 6.5 Setting Variables
+# https://www.gnu.org/software/make/manual/html_node/Setting.html
+# Variables defined with ‘=’ are recursively expanded variables.
+# If you’d like a variable to be set to a value only if it’s not
+# already set, then you can use the shorthand operator ‘?=’ instead
+# of ‘=’.
+# Variables defined with ‘:=’ or ‘::=’ are simply expanded variables.
 PYTHON ?= python3
-STAN_LANG = stan_lang.json
+STAN_LANG_JSON = stan_lang.json
+# This file must have a version string at * to ensure auto-retrieval.
+FUNCTIONS_FILE := $(wildcard stan-functions-*.txt)
 
 all : json
 
-json: $(STAN_LANG)
+json: $(STAN_LANG_JSON)
 
-$(STAN_LANG) : create_stan_lang.py
-	$(PYTHON) $< $@
+# 10.5.3 Automatic Variables
+# https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html
+$(STAN_LANG_JSON) : $(FUNCTIONS_FILE) stan-lang-keywords.yaml
+	$(PYTHON) create_stan_lang.py $(STAN_LANG_JSON)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In particular, this is used to generate the keyword and function lists in:
 - `stan-lang-keywords.yaml`
 - `stan-functions-*.txt`
 
-The `stan-functions-*.txt` file is available as `stan-functions.txt` in the [rstan repo](https://github.com/stan-dev/rstan/blob/develop/rstan/rstan/tools/stan-functions.txt). Several errors have been addressed.
+The `stan-functions-*.txt` file is available as `stan-functions.txt` in the [rstan repo](https://github.com/stan-dev/rstan/blob/develop/rstan/rstan/tools/stan-functions.txt). Several errors have been addressed. Note that the name must contain the version string, for example, `stan-functions-2.19.0.txt`. Some scripts use this version string to record the current version.
 
 ## References
 

--- a/stan-functions-2.19.0.txt
+++ b/stan-functions-2.19.0.txt
@@ -57,13 +57,13 @@ beta_proportion_rng;(reals mu, reals kappa); R
 beta;~; real
 beta_rng;(reals alpha, reals beta); R
 binary_log_loss;(int y, real y_hat); real
-binomia_cdf;(ints n, ints N, reals theta); real
-binomia_lccdf;(ints n , ints N, reals theta); real
-binomia_lcdf;(ints n , ints N, reals theta); real
+binomial_cdf;(ints n, ints N, reals theta); real
+binomial_lccdf;(ints n , ints N, reals theta); real
+binomial_lcdf;(ints n , ints N, reals theta); real
 binomial_coefficient_log;(real x, real y); real
 binomial_logit_lpmf;(ints n , ints N, reals alpha); real
 binomial_logit;~; real
-binomia_lpmf;(ints n , ints N, reals theta); real
+binomial_lpmf;(ints n , ints N, reals theta); real
 binomial;~; real
 binomial_rng;(ints N, reals theta); R
 block;(matrix x, int i, int j, int n_rows, int n_cols); matrix

--- a/stan_lang.json
+++ b/stan_lang.json
@@ -1300,7 +1300,7 @@
         }
       ]
     },
-    "binomia_cdf": {
+    "binomial_cdf": {
       "density": false,
       "deprecated": false,
       "keyword": false,
@@ -1311,99 +1311,6 @@
       "math": true,
       "operator": false,
       "sampling": null,
-      "signatures": [
-        {
-          "args": [
-            {
-              "name": "n",
-              "type": "ints"
-            },
-            {
-              "name": "N",
-              "type": "ints"
-            },
-            {
-              "name": "theta",
-              "type": "reals"
-            }
-          ],
-          "return": "real"
-        }
-      ]
-    },
-    "binomia_lccdf": {
-      "density": false,
-      "deprecated": false,
-      "keyword": false,
-      "lccdf": true,
-      "lcdf": false,
-      "lpdf": false,
-      "lpmf": false,
-      "math": false,
-      "operator": false,
-      "sampling": null,
-      "signatures": [
-        {
-          "args": [
-            {
-              "name": "n",
-              "type": "ints"
-            },
-            {
-              "name": "N",
-              "type": "ints"
-            },
-            {
-              "name": "theta",
-              "type": "reals"
-            }
-          ],
-          "return": "real"
-        }
-      ]
-    },
-    "binomia_lcdf": {
-      "density": false,
-      "deprecated": false,
-      "keyword": false,
-      "lccdf": false,
-      "lcdf": true,
-      "lpdf": false,
-      "lpmf": false,
-      "math": false,
-      "operator": false,
-      "sampling": null,
-      "signatures": [
-        {
-          "args": [
-            {
-              "name": "n",
-              "type": "ints"
-            },
-            {
-              "name": "N",
-              "type": "ints"
-            },
-            {
-              "name": "theta",
-              "type": "reals"
-            }
-          ],
-          "return": "real"
-        }
-      ]
-    },
-    "binomia_lpmf": {
-      "density": true,
-      "deprecated": false,
-      "keyword": false,
-      "lccdf": false,
-      "lcdf": false,
-      "lpdf": false,
-      "lpmf": true,
-      "math": false,
-      "operator": false,
-      "sampling": "binomia",
       "signatures": [
         {
           "args": [
@@ -1451,6 +1358,68 @@
         }
       ]
     },
+    "binomial_lccdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": true,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": false,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "N",
+              "type": "ints"
+            },
+            {
+              "name": "theta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "binomial_lcdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": true,
+      "lpdf": false,
+      "lpmf": false,
+      "math": false,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "N",
+              "type": "ints"
+            },
+            {
+              "name": "theta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "binomial_logit_lpmf": {
       "density": true,
       "deprecated": false,
@@ -1475,6 +1444,37 @@
             },
             {
               "name": "alpha",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "binomial_lpmf": {
+      "density": true,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": true,
+      "math": false,
+      "operator": false,
+      "sampling": "binomial",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "N",
+              "type": "ints"
+            },
+            {
+              "name": "theta",
               "type": "reals"
             }
           ],


### PR DESCRIPTION
Several typos were introduced in the previous pull request due to the typos in the upstream file (https://github.com/stan-dev/rstan/blob/develop/rstan/rstan/tools/stan-functions.txt).

Also modify and document the Makefile for maintainability.