### PR TITLE
Update to 2.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Copy the resulting file named `stan-functions-2_24.txt` to this repo.
 
 
 ## Notes on Changes
+
+### 2.28.1 (2021-11-03)
+- Update functions to latest and parse new `array [] int` syntax as replacement for `int[]` syntax
+- Add `.^` and `%/%` operators
+- Add support for the `complex` type
+
 ###  2.24.x (2020-08-17)
 - Explain function signature file generation using the extract_function_sigs.py script
 

--- a/create_stan_lang.py
+++ b/create_stan_lang.py
@@ -23,13 +23,11 @@ def parse_args(argtext):
             arg = arg.strip()
             if arg == '...':
                 ret.append({'type': '...', 'name': '...'})
-            elif arg.startswith('data '):
-                # special case for ode solvers
-                _data, argtype, argname = arg.split(' ')
-                ret.append({'type': "data " + argtype.strip(), 'name': argname.strip()})
             else:
-                argtype, argname = arg.split(' ')
-                ret.append({'type': argtype.strip(), 'name': argname.strip()})
+                # 'prefixes' could be things like 'data', 'array[]', 'data array[]', etc
+                *prefixes, argtype, argname = arg.split(' ')
+                prefix = ' '.join(p.strip() for p in prefixes) + (' ' if prefixes else '')
+                ret.append({'type': prefix + argtype.strip(), 'name': argname.strip()})
     return ret
 
 

--- a/stan-functions-2_28.txt
+++ b/stan-functions-2_28.txt
@@ -1,15 +1,20 @@
-# This file is semicolon delimited. docs ./extract_function_sigs.py 2 24
+# This file is semicolon delimited
 StanFunction; Arguments; ReturnType
 Phi; (T x); R
 Phi_approx; (T x); R
 abs; (T x); R
+abs; (complex z); real
 acos; (T x); R
+acos; (complex z); complex
 acosh; (T x); R
+acosh; (complex z); complex
 add_diag; (matrix m, real d); matrix
 add_diag; (matrix m, row_vector d); matrix
 add_diag; (matrix m, vector d); matrix
-algebra_solver; (function algebra_system, vector y_guess, vector theta, real[] x_r, int[] x_i); vector
-algebra_solver; (function algebra_system, vector y_guess, vector theta, real[] x_r, int[] x_i, real rel_tol, real f_tol, int max_steps); vector
+algebra_solver; (function algebra_system, vector y_guess, vector theta, data array[] real x_r, array[] int x_i); vector
+algebra_solver; (function algebra_system, vector y_guess, vector theta, data array[] real x_r, array[] int x_i, data real rel_tol, data real f_tol, int max_steps); vector
+algebra_solver_newton; (function algebra_system, vector y_guess, vector theta, data array[] real x_r, array[] int x_i); vector
+algebra_solver_newton; (function algebra_system, vector y_guess, vector theta, data array[] real x_r, array[] int x_i, data real rel_tol, data real f_tol, int max_steps); vector
 append_array; (T x, T y); T
 append_col; (matrix x, matrix y); matrix
 append_col; (matrix x, vector y); matrix
@@ -25,72 +30,102 @@ append_row; (row_vector x, matrix y); matrix
 append_row; (row_vector x, row_vector y); matrix
 append_row; (vector x, real y); vector
 append_row; (vector x, vector y); vector
+arg; (complex z); real
 asin; (T x); R
+asin; (complex z); complex
 asinh; (T x); R
+asinh; (complex z); complex
 atan2; (real y, real x); real
 atan; (T x); R
+atan; (complex z); complex
 atanh; (T x); R
+atanh; (complex z); complex
 bernoulli; ~; real
 bernoulli_cdf; (ints y, reals theta); real
 bernoulli_lccdf; (ints y | reals theta); real
 bernoulli_lcdf; (ints y | reals theta); real
 bernoulli_logit; ~; real
 bernoulli_logit_glm; ~; real
+bernoulli_logit_glm_lpmf; (array[] int y | matrix x, real alpha, vector beta); real
+bernoulli_logit_glm_lpmf; (array[] int y | matrix x, vector alpha, vector beta); real
+bernoulli_logit_glm_lpmf; (array[] int y | row_vector x, real alpha, vector beta); real
+bernoulli_logit_glm_lpmf; (array[] int y | row_vector x, vector alpha, vector beta); real
 bernoulli_logit_glm_lpmf; (int y | matrix x, real alpha, vector beta); real
 bernoulli_logit_glm_lpmf; (int y | matrix x, vector alpha, vector beta); real
-bernoulli_logit_glm_lpmf; (int[] y | matrix x, real alpha, vector beta); real
-bernoulli_logit_glm_lpmf; (int[] y | matrix x, vector alpha, vector beta); real
-bernoulli_logit_glm_lpmf; (int[] y | row_vector x, real alpha, vector beta); real
-bernoulli_logit_glm_lpmf; (int[] y | row_vector x, vector alpha, vector beta); real
+bernoulli_logit_glm_lupmf; (array[] int y | matrix x, real alpha, vector beta); real
+bernoulli_logit_glm_lupmf; (array[] int y | matrix x, vector alpha, vector beta); real
+bernoulli_logit_glm_lupmf; (array[] int y | row_vector x, real alpha, vector beta); real
+bernoulli_logit_glm_lupmf; (array[] int y | row_vector x, vector alpha, vector beta); real
+bernoulli_logit_glm_lupmf; (int y | matrix x, real alpha, vector beta); real
+bernoulli_logit_glm_lupmf; (int y | matrix x, vector alpha, vector beta); real
 bernoulli_logit_lpmf; (ints y | reals alpha); real
+bernoulli_logit_lupmf; (ints y | reals alpha); real
 bernoulli_logit_rng; (reals alpha); R
 bernoulli_lpmf; (ints y | reals theta); real
+bernoulli_lupmf; (ints y | reals theta); real
 bernoulli_rng; (reals theta); R
+bessel_first_kind; (T1 x, T2 y); R
 bessel_first_kind; (int v, real x); real
+bessel_second_kind; (T1 x, T2 y); R
 bessel_second_kind; (int v, real x); real
+beta; (T1 x, T2 y); R
+beta; (real alpha, real beta); real
 beta; ~; real
 beta_binomial; ~; real
 beta_binomial_cdf; (ints n, ints N, reals alpha, reals beta); real
 beta_binomial_lccdf; (ints n | ints N, reals alpha, reals beta); real
 beta_binomial_lcdf; (ints n | ints N, reals alpha, reals beta); real
 beta_binomial_lpmf; (ints n | ints N, reals alpha, reals beta); real
+beta_binomial_lupmf; (ints n | ints N, reals alpha, reals beta); real
 beta_binomial_rng; (ints N, reals alpha, reals beta); R
 beta_cdf; (reals theta, reals alpha, reals beta); real
 beta_lccdf; (reals theta | reals alpha, reals beta); real
 beta_lcdf; (reals theta | reals alpha, reals beta); real
 beta_lpdf; (reals theta | reals alpha, reals beta); real
+beta_lupdf; (reals theta | reals alpha, reals beta); real
 beta_proportion; ~; real
 beta_proportion_lccdf; (reals theta | reals mu, reals kappa); real
 beta_proportion_lcdf; (reals theta | reals mu, reals kappa); real
 beta_proportion_lpdf; ~; real
+beta_proportion_lupdf; ~; real
 beta_proportion_rng; (reals mu, reals kappa); R
 beta_rng; (reals alpha, reals beta); R
+binary_log_loss; (T1 x, T2 y); R
 binary_log_loss; (int y, real y_hat); real
 binomial; ~; real
 binomial_cdf; (ints n, ints N, reals theta); real
+binomial_coefficient_log; (T1 x, T2 y); R
 binomial_coefficient_log; (real x, real y); real
 binomial_lccdf; (ints n | ints N, reals theta); real
 binomial_lcdf; (ints n | ints N, reals theta); real
 binomial_logit; ~; real
 binomial_logit_lpmf; (ints n | ints N, reals alpha); real
+binomial_logit_lupmf; (ints n | ints N, reals alpha); real
 binomial_lpmf; (ints n | ints N, reals theta); real
+binomial_lupmf; (ints n | ints N, reals theta); real
 binomial_rng; (ints N, reals theta); R
 block; (matrix x, int i, int j, int n_rows, int n_cols); matrix
 categorical; ~; real
 categorical_logit; ~; real
 categorical_logit_glm; ~; real
+categorical_logit_glm_lpmf; (array[] int y | vector theta); real
 categorical_logit_glm_lpmf; (int y | matrix x, vector alpha, matrix beta); real
 categorical_logit_glm_lpmf; (int y | row_vector x, vector alpha, matrix beta); real
-categorical_logit_glm_lpmf; (int[] y | vector theta); real
+categorical_logit_glm_lupmf; (array[] int y | vector theta); real
+categorical_logit_glm_lupmf; (int y | matrix x, vector alpha, matrix beta); real
+categorical_logit_glm_lupmf; (int y | row_vector x, vector alpha, matrix beta); real
 categorical_logit_lpmf; (ints y | vector beta); real
+categorical_logit_lupmf; (ints y | vector beta); real
 categorical_logit_rng; (vector beta); int
 categorical_lpmf; (ints y | vector theta); real
+categorical_lupmf; (ints y | vector theta); real
 categorical_rng; (vector theta); int
 cauchy; ~; real
 cauchy_cdf; (reals y, reals mu, reals sigma); real
 cauchy_lccdf; (reals y | reals mu, reals sigma); real
 cauchy_lcdf; (reals y | reals mu, reals sigma); real
 cauchy_lpdf; (reals y | reals mu, reals sigma); real
+cauchy_lupdf; (reals y | reals mu, reals sigma); real
 cauchy_rng; (reals mu, reals sigma); R
 cbrt; (T x); R
 ceil; (T x); R
@@ -99,8 +134,11 @@ chi_square_cdf; (reals y, reals nu); real
 chi_square_lccdf; (reals y | reals nu); real
 chi_square_lcdf; (reals y | reals nu); real
 chi_square_lpdf; (reals y | reals nu); real
+chi_square_lupdf; (reals y | reals nu); real
 chi_square_rng; (reals nu); R
+chol2inv; (matrix L); matrix
 cholesky_decompose; (matrix A); matrix
+choose; (T1 x, T2 y); R
 choose; (int x, int y); int
 col; (matrix x, int n); vector
 cols; (matrix x); int
@@ -112,21 +150,24 @@ columns_dot_product; (vector x, vector y); row_vector
 columns_dot_self; (matrix x); row_vector
 columns_dot_self; (row_vector x); row_vector
 columns_dot_self; (vector x); row_vector
+conj; (complex z); complex
 cos; (T x); R
+cos; (complex z); complex
 cosh; (T x); R
-cov_exp_quad; (real[] x, real alpha, real rho); matrix
-cov_exp_quad; (real[] x1, real[] x2, real alpha, real rho); matrix
+cosh; (complex z); complex
+cov_exp_quad; (array[] real x, real alpha, real rho); matrix
+cov_exp_quad; (array[] real x1, array[] real x2, real alpha, real rho); matrix
 cov_exp_quad; (row_vectors x, real alpha, real rho); matrix
 cov_exp_quad; (row_vectors x1, row_vectors x2, real alpha, real rho); matrix
 cov_exp_quad; (vectors x, real alpha, real rho); matrix
 cov_exp_quad; (vectors x1, vectors x2, real alpha, real rho); matrix
 crossprod; (matrix x); matrix
-csr_extract_u; (matrix a); int[]
-csr_extract_v; (matrix a); int[]
+csr_extract_u; (matrix a); array[] int
+csr_extract_v; (matrix a); array[] int
 csr_extract_w; (matrix a); vector
-csr_matrix_times_vector; (int m, int n, vector w, int[] v, int[] u, vector b); vector
-csr_to_dense_matrix; (int m, int n, vector w, int[] v, int[] u); matrix
-cumulative_sum; (real[] x); real[]
+csr_matrix_times_vector; (int m, int n, vector w, array[] int v, array[] int u, vector b); vector
+csr_to_dense_matrix; (int m, int n, vector w, array[] int v, array[] int u); matrix
+cumulative_sum; (array[] real x); array[] real
 cumulative_sum; (row_vector rv); row_vector
 cumulative_sum; (vector v); vector
 determinant; (matrix A); real
@@ -137,10 +178,18 @@ diag_pre_multiply; (row_vector rv, matrix m); matrix
 diag_pre_multiply; (vector v, matrix m); matrix
 diagonal; (matrix x); vector
 digamma; (T x); R
-dims; (T x); int[]
+dims; (T x); array[] int
 dirichlet; ~; real
 dirichlet_lpdf; (vector theta | vector alpha); real
+dirichlet_lupdf; (vector theta | vector alpha); real
 dirichlet_rng; (vector alpha); vector
+discrete_range; ~; real
+discrete_range_cdf; (ints y, ints l, ints u); real
+discrete_range_lccdf; (ints y | ints l, ints u); real
+discrete_range_lcdf; (ints y | ints l, ints u); real
+discrete_range_lpmf; (ints y | ints l, ints u); real
+discrete_range_lupmf; (ints y | ints l, ints u); real
+discrete_range_rng; (ints l, ints u); int
 distance; (row_vector x, row_vector y); real
 distance; (row_vector x, vector y); real
 distance; (vector x, row_vector y); real
@@ -156,19 +205,22 @@ double_exponential_cdf; (reals y, reals mu, reals sigma); real
 double_exponential_lccdf; (reals y | reals mu, reals sigma); real
 double_exponential_lcdf; (reals y | reals mu, reals sigma); real
 double_exponential_lpdf; (reals y | reals mu, reals sigma); real
+double_exponential_lupdf; (reals y | reals mu, reals sigma); real
 double_exponential_rng; (reals mu, reals sigma); R
-e; ~; real
+e; (); real
 eigenvalues_sym; (matrix A); vector
 eigenvectors_sym; (matrix A); matrix
 erf; (T x); R
 erfc; (T x); R
 exp2; (T x); R
 exp; (T x); R
+exp; (complex z); complex
 exp_mod_normal; ~; real
 exp_mod_normal_cdf; (reals y, reals mu, reals sigma, reals lambda); real
 exp_mod_normal_lccdf; (reals y | reals mu, reals sigma, reals lambda); real
 exp_mod_normal_lcdf; (reals y | reals mu, reals sigma, reals lambda); real
 exp_mod_normal_lpdf; (reals y | reals mu, reals sigma, reals lambda); real
+exp_mod_normal_lupdf; (reals y | reals mu, reals sigma, reals lambda); real
 exp_mod_normal_rng; (reals mu, reals sigma, reals lambda); R
 expm1; (T x); R
 exponential; ~; real
@@ -176,51 +228,80 @@ exponential_cdf; (reals y, reals beta); real
 exponential_lccdf; (reals y | reals beta); real
 exponential_lcdf; (reals y | reals beta); real
 exponential_lpdf; (reals y | reals beta); real
+exponential_lupdf; (reals y | reals beta); real
 exponential_rng; (reals beta); R
 fabs; (T x); R
+falling_factorial; (T1 x, T2 y); R
 falling_factorial; (real x, real n); real
+fdim; (T1 x, T2 y); R
 fdim; (real x, real y); real
 floor; (T x); R
 fma; (real x, real y, real z); real
+fmax; (T1 x, T2 y); R
 fmax; (real x, real y); real
+fmin; (T1 x, T2 y); R
 fmin; (real x, real y); real
+fmod; (T1 x, T2 y); R
 fmod; (real x, real y); real
 frechet; ~; real
 frechet_cdf; (reals y, reals alpha, reals sigma); real
 frechet_lccdf; (reals y | reals alpha, reals sigma); real
 frechet_lcdf; (reals y | reals alpha, reals sigma); real
 frechet_lpdf; (reals y | reals alpha, reals sigma); real
+frechet_lupdf; (reals y | reals alpha, reals sigma); real
 frechet_rng; (reals alpha, reals sigma); R
 gamma; ~; real
 gamma_cdf; (reals y, reals alpha, reals beta); real
 gamma_lccdf; (reals y | reals alpha, reals beta); real
 gamma_lcdf; (reals y | reals alpha, reals beta); real
 gamma_lpdf; (reals y | reals alpha, reals beta); real
+gamma_lupdf; (reals y | reals alpha, reals beta); real
+gamma_p; (T1 x, T2 y); R
 gamma_p; (real a, real z); real
+gamma_q; (T1 x, T2 y); R
 gamma_q; (real a, real z); real
 gamma_rng; (reals alpha, reals beta); R
 gaussian_dlm_obs; ~; real
 gaussian_dlm_obs_lpdf; (matrix y | matrix F, matrix G, matrix V, matrix W, vector m0, matrix C0); real
 gaussian_dlm_obs_lpdf; (matrix y | matrix F, matrix G, vector V, matrix W, vector m0, matrix C0); real
-get_lp; ~; real
+gaussian_dlm_obs_lupdf; (matrix y | matrix F, matrix G, matrix V, matrix W, vector m0, matrix C0); real
+gaussian_dlm_obs_lupdf; (matrix y | matrix F, matrix G, vector V, matrix W, vector m0, matrix C0); real
+generalized_inverse; (matrix A); matrix
+get_imag; (complex z); real
+get_lp; (); real
+get_real; (complex z); real
 gumbel; ~; real
 gumbel_cdf; (reals y, reals mu, reals beta); real
 gumbel_lccdf; (reals y | reals mu, reals beta); real
 gumbel_lcdf; (reals y | reals mu, reals beta); real
 gumbel_lpdf; (reals y | reals mu, reals beta); real
+gumbel_lupdf; (reals y | reals mu, reals beta); real
 gumbel_rng; (reals mu, reals beta); R
-head; (T[] sv, int n); T[]
+head; (array[] T sv, int n); array[] T
 head; (row_vector rv, int n); row_vector
 head; (vector v, int n); vector
+hmm_hidden_state_prob; (matrix log_omega, matrix Gamma, vector rho); matrix
+hmm_latent_rng; (matrix log_omega, matrix Gamma, vector rho); array[] int
+hmm_marginal; (matrix log_omega, matrix Gamma, vector rho); real
 hypergeometric; ~; real
 hypergeometric_lpmf; (int n | int N, int a, int b); real
+hypergeometric_lupmf; (int n | int N, int a, int b); real
 hypergeometric_rng; (int N, int a, int2 b); int
+hypot; (T1 x, T2 y); R
 hypot; (real x, real y); real
+identity_matrix; (int k); matrix
 inc_beta; (real alpha, real beta, real x); real
 int_step; (int x); int
 int_step; (real x); int
-integrate_1d; (function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i), real relative_tolerance); real
-integrate_1d; (function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i); real
+integrate_1d; (function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i), real relative_tolerance); real
+integrate_1d; (function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i); real
+integrate_ode; (function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i); array[,] real
+integrate_ode_adams; (function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i); array[,] real
+integrate_ode_adams; (function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i, real rel_tol, real abs_tol, int max_num_steps); array[,] real
+integrate_ode_bdf; (function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i); array[,] real
+integrate_ode_bdf; (function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i, real rel_tol, real abs_tol, int max_num_steps); array[,] real
+integrate_ode_rk45; (function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i); array[,] real
+integrate_ode_rk45; (function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i, real rel_tol, real abs_tol, int max_num_steps); array[,] real
 inv; (T x); R
 inv_Phi; (T x); R
 inv_chi_square; ~; real
@@ -228,6 +309,7 @@ inv_chi_square_cdf; (reals y, reals nu); real
 inv_chi_square_lccdf; (reals y | reals nu); real
 inv_chi_square_lcdf; (reals y | reals nu); real
 inv_chi_square_lpdf; (reals y | reals nu); real
+inv_chi_square_lupdf; (reals y | reals nu); real
 inv_chi_square_rng; (reals nu); R
 inv_cloglog; (T x); R
 inv_gamma; ~; real
@@ -235,48 +317,71 @@ inv_gamma_cdf; (reals y, reals alpha, reals beta); real
 inv_gamma_lccdf; (reals y | reals alpha, reals beta); real
 inv_gamma_lcdf; (reals y | reals alpha, reals beta); real
 inv_gamma_lpdf; (reals y | reals alpha, reals beta); real
+inv_gamma_lupdf; (reals y | reals alpha, reals beta); real
 inv_gamma_rng; (reals alpha, reals beta); R
 inv_logit; (T x); R
 inv_sqrt; (T x); R
 inv_square; (T x); R
 inv_wishart; ~; real
 inv_wishart_lpdf; (matrix W | real nu, matrix Sigma); real
+inv_wishart_lupdf; (matrix W | real nu, matrix Sigma); real
 inv_wishart_rng; (real nu, matrix Sigma); matrix
 inverse; (matrix A); matrix
 inverse_spd; (matrix A); matrix
 is_inf; (real x); int
 is_nan; (real x); int
+lambert_w0; (reals x); R
+lambert_wm1; (T x); R
+lbeta; (T1 x, T2 y); R
 lbeta; (real alpha, real beta); real
+lchoose; (T1 x, T2 y); R
 lchoose; (real x, real y); real
+ldexp; (T1 x, T2 y); R
+ldexp; (real x, int y); real
 lgamma; (T x); R
+linspaced_array; (int n, data real lower, data real upper); array[] real
+linspaced_int_array; (int n, int lower, int upper); array[] real
+linspaced_row_vector; (int n, data real lower, data real upper); row_vector
+linspaced_vector; (int n, data real lower, data real upper); vector
 lkj_corr; ~; real
 lkj_corr_cholesky; ~; real
 lkj_corr_cholesky_lpdf; (matrix L | real eta); real
+lkj_corr_cholesky_lupdf; (matrix L | real eta); real
 lkj_corr_cholesky_rng; (int K, real eta); matrix
 lkj_corr_lpdf; (matrix y | real eta); real
+lkj_corr_lupdf; (matrix y | real eta); real
 lkj_corr_rng; (int K, real eta); matrix
+lmgamma; (T1 x, T2 y); R
 lmgamma; (int n, real x); real
+lmultiply; (T1 x, T2 y); R
 lmultiply; (real x, real y); real
+log10; (); real
 log10; (T x); R
-log10; ~; real
+log10; (complex z); complex
 log1m; (T x); R
 log1m_exp; (T x); R
 log1m_inv_logit; (T x); R
 log1p; (T x); R
 log1p_exp; (T x); R
+log2; (); real
 log2; (T x); R
-log2; ~; real
 log; (T x); R
+log; (complex z); complex
 log_determinant; (matrix A); real
+log_diff_exp; (T1 x, T2 y); R
 log_diff_exp; (real x, real y); real
 log_falling_factorial; (real x, real n); real
 log_inv_logit; (T x); R
+log_inv_logit_diff; (T1 x, T2 y); R
 log_mix; (real theta, real lp1, real lp2); real
+log_modified_bessel_first_kind; (T1 x, T2 y); R
+log_modified_bessel_first_kind; (real v, real z); real
+log_rising_factorial; (T1 x, T2 y); R
 log_rising_factorial; (real x, real n); real
 log_softmax; (vector x); vector
+log_sum_exp; (array[] real x); real
 log_sum_exp; (matrix x); real
 log_sum_exp; (real x, real y); real
-log_sum_exp; (real[] x); real
 log_sum_exp; (row_vector x); real
 log_sum_exp; (vector x); real
 logistic; ~; real
@@ -284,6 +389,7 @@ logistic_cdf; (reals y, reals mu, reals sigma); real
 logistic_lccdf; (reals y | reals mu, reals sigma); real
 logistic_lcdf; (reals y | reals mu, reals sigma); real
 logistic_lpdf; (reals y | reals mu, reals sigma); real
+logistic_lupdf; (reals y | reals mu, reals sigma); real
 logistic_rng; (reals mu, reals sigma); R
 logit; (T x); R
 lognormal; ~; real
@@ -291,16 +397,17 @@ lognormal_cdf; (reals y, reals mu, reals sigma); real
 lognormal_lccdf; (reals y | reals mu, reals sigma); real
 lognormal_lcdf; (reals y | reals mu, reals sigma); real
 lognormal_lpdf; (reals y | reals mu, reals sigma); real
+lognormal_lupdf; (reals y | reals mu, reals sigma); real
 lognormal_rng; (reals mu, reals sigma); R
-machine_precision; ~; real
-map_rect; (F f, vector phi, vector[] theta, data real[,] x_r, data int[,] x_i); vector
+machine_precision; (); real
+map_rect; (F f, vector phi, array[] vector theta, data array[,] real x_r, data array[,] int x_i); vector
 matrix_exp; (matrix A); matrix
 matrix_exp_multiply; (matrix A, matrix B); matrix
 matrix_power; (matrix A, int B); matrix
+max; (array[] int x); int
+max; (array[] real x); real
 max; (int x, int y); int
-max; (int[] x); int
 max; (matrix x); real
-max; (real[] x); real
 max; (row_vector x); real
 max; (vector x); real
 mdivide_left_spd; (matrix A, matrix B); vector
@@ -311,28 +418,36 @@ mdivide_right_spd; (matrix B, matrix A); matrix
 mdivide_right_spd; (row_vector b, matrix A); row_vector
 mdivide_right_tri_low; (matrix B, matrix A); matrix
 mdivide_right_tri_low; (row_vector b, matrix A); row_vector
+mean; (array[] real x); real
 mean; (matrix x); real
-mean; (real[] x); real
 mean; (row_vector x); real
 mean; (vector x); real
+min; (array[] int x); int
+min; (array[] real x); real
 min; (int x, int y); int
-min; (int[] x); int
 min; (matrix x); real
-min; (real[] x); real
 min; (row_vector x); real
 min; (vector x); real
+modified_bessel_first_kind; (T1 x, T2 y); R
 modified_bessel_first_kind; (int v, real z); real
+modified_bessel_second_kind; (T1 x, T2 y); R
 modified_bessel_second_kind; (int v, real z); real
 multi_gp; ~; real
 multi_gp_cholesky; ~; real
 multi_gp_cholesky_lpdf; (matrix y | matrix L, vector w); real
+multi_gp_cholesky_lupdf; (matrix y | matrix L, vector w); real
 multi_gp_lpdf; (matrix y | matrix Sigma, vector w); real
+multi_gp_lupdf; (matrix y | matrix Sigma, vector w); real
 multi_normal; ~; real
 multi_normal_cholesky; ~; real
 multi_normal_cholesky_lpdf; (row_vectors y | row_vectors mu, matrix L); real
 multi_normal_cholesky_lpdf; (row_vectors y | vectors mu, matrix L); real
 multi_normal_cholesky_lpdf; (vectors y | row_vectors mu, matrix L); real
 multi_normal_cholesky_lpdf; (vectors y | vectors mu, matrix L); real
+multi_normal_cholesky_lupdf; (row_vectors y | row_vectors mu, matrix L); real
+multi_normal_cholesky_lupdf; (row_vectors y | vectors mu, matrix L); real
+multi_normal_cholesky_lupdf; (vectors y | row_vectors mu, matrix L); real
+multi_normal_cholesky_lupdf; (vectors y | vectors mu, matrix L); real
 multi_normal_cholesky_rng; (row_vector mu, matrix L); vector
 multi_normal_cholesky_rng; (row_vectors mu, matrix L); vectors
 multi_normal_cholesky_rng; (vector mu, matrix L); vector
@@ -341,11 +456,19 @@ multi_normal_lpdf; (row_vectors y | row_vectors mu, matrix Sigma); real
 multi_normal_lpdf; (row_vectors y | vectors mu, matrix Sigma); real
 multi_normal_lpdf; (vectors y | row_vectors mu, matrix Sigma); real
 multi_normal_lpdf; (vectors y | vectors mu, matrix Sigma); real
+multi_normal_lupdf; (row_vectors y | row_vectors mu, matrix Sigma); real
+multi_normal_lupdf; (row_vectors y | vectors mu, matrix Sigma); real
+multi_normal_lupdf; (vectors y | row_vectors mu, matrix Sigma); real
+multi_normal_lupdf; (vectors y | vectors mu, matrix Sigma); real
 multi_normal_prec; ~; real
 multi_normal_prec_lpdf; (row_vectors y | row_vectors mu, matrix Omega); real
 multi_normal_prec_lpdf; (row_vectors y | vectors mu, matrix Omega); real
 multi_normal_prec_lpdf; (vectors y | row_vectors mu, matrix Omega); real
 multi_normal_prec_lpdf; (vectors y | vectors mu, matrix Omega); real
+multi_normal_prec_lupdf; (row_vectors y | row_vectors mu, matrix Omega); real
+multi_normal_prec_lupdf; (row_vectors y | vectors mu, matrix Omega); real
+multi_normal_prec_lupdf; (vectors y | row_vectors mu, matrix Omega); real
+multi_normal_prec_lupdf; (vectors y | vectors mu, matrix Omega); real
 multi_normal_rng; (row_vector mu, matrix Sigma); vector
 multi_normal_rng; (row_vectors mu, matrix Sigma); vectors
 multi_normal_rng; (vector mu, matrix Sigma); vector
@@ -355,16 +478,23 @@ multi_student_t_lpdf; (row_vectors y | real nu, row_vectors mu, matrix Sigma); r
 multi_student_t_lpdf; (row_vectors y | real nu, vectors mu, matrix Sigma); real
 multi_student_t_lpdf; (vectors y | real nu, row_vectors mu, matrix Sigma); real
 multi_student_t_lpdf; (vectors y | real nu, vectors mu, matrix Sigma); real
+multi_student_t_lupdf; (row_vectors y | real nu, row_vectors mu, matrix Sigma); real
+multi_student_t_lupdf; (row_vectors y | real nu, vectors mu, matrix Sigma); real
+multi_student_t_lupdf; (vectors y | real nu, row_vectors mu, matrix Sigma); real
+multi_student_t_lupdf; (vectors y | real nu, vectors mu, matrix Sigma); real
 multi_student_t_rng; (real nu, row_vector mu, matrix Sigma); vector
 multi_student_t_rng; (real nu, row_vectors mu, matrix Sigma); vectors
 multi_student_t_rng; (real nu, vector mu, matrix Sigma); vector
 multi_student_t_rng; (real nu, vectors mu, matrix Sigma); vectors
 multinomial; ~; real
 multinomial_logit; ~; real
-multinomial_logit_lpmf; (int[] y | vector theta); real
-multinomial_logit_rng; (vector theta, int N); int[]
-multinomial_lpmf; (int[] y | vector theta); real
-multinomial_rng; (vector theta, int N); int[]
+multinomial_logit_lpmf; (array[] int y | vector theta); real
+multinomial_logit_lupmf; (array[] int y | vector theta); real
+multinomial_logit_rng; (vector theta, int N); array[] int
+multinomial_lpmf; (array[] int y | vector theta); real
+multinomial_lupmf; (array[] int y | vector theta); real
+multinomial_rng; (vector theta, int N); array[] int
+multiply_log; (T1 x, T2 y); R
 multiply_log; (real x, real y); real
 multiply_lower_tri_self_transpose; (matrix x); matrix
 neg_binomial; ~; real
@@ -374,22 +504,32 @@ neg_binomial_2_lccdf; (ints n | reals mu, reals phi); real
 neg_binomial_2_lcdf; (ints n | reals mu, reals phi); real
 neg_binomial_2_log; ~; real
 neg_binomial_2_log_glm; ~; real
+neg_binomial_2_log_glm_lpmf; (array[] int y | matrix x, real alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lpmf; (array[] int y | matrix x, vector alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lpmf; (array[] int y | row_vector x, real alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lpmf; (array[] int y | row_vector x, vector alpha, vector beta, real phi); real
 neg_binomial_2_log_glm_lpmf; (int y | matrix x, real alpha, vector beta, real phi); real
 neg_binomial_2_log_glm_lpmf; (int y | matrix x, vector alpha, vector beta, real phi); real
-neg_binomial_2_log_glm_lpmf; (int[] y | matrix x, real alpha, vector beta, real phi); real
-neg_binomial_2_log_glm_lpmf; (int[] y | matrix x, vector alpha, vector beta, real phi); real
-neg_binomial_2_log_glm_lpmf; (int[] y | row_vector x, real alpha, vector beta, real phi); real
-neg_binomial_2_log_glm_lpmf; (int[] y | row_vector x, vector alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lupmf; (array[] int y | matrix x, real alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lupmf; (array[] int y | matrix x, vector alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lupmf; (array[] int y | row_vector x, real alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lupmf; (array[] int y | row_vector x, vector alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lupmf; (int y | matrix x, real alpha, vector beta, real phi); real
+neg_binomial_2_log_glm_lupmf; (int y | matrix x, vector alpha, vector beta, real phi); real
 neg_binomial_2_log_lpmf; (ints n | reals eta, reals phi); real
+neg_binomial_2_log_lupmf; (ints n | reals eta, reals phi); real
 neg_binomial_2_log_rng; (reals eta, reals phi); R
 neg_binomial_2_lpmf; (ints n | reals mu, reals phi); real
+neg_binomial_2_lupmf; (ints n | reals mu, reals phi); real
 neg_binomial_2_rng; (reals mu, reals phi); R
 neg_binomial_cdf; (ints n, reals alpha, reals beta); real
 neg_binomial_lccdf; (ints n | reals alpha, reals beta); real
 neg_binomial_lcdf; (ints n | reals alpha, reals beta); real
 neg_binomial_lpmf; (ints n | reals alpha, reals beta); real
+neg_binomial_lupmf; (ints n | reals alpha, reals beta); real
 neg_binomial_rng; (reals alpha, reals beta); R
-negative_infinity; ~; real
+negative_infinity; (); real
+norm; (complex z); real
 normal; ~; real
 normal_cdf; (reals y, reals mu, reals sigma); real
 normal_id_glm; ~; real
@@ -399,25 +539,52 @@ normal_id_glm_lpdf; (vector y | matrix x, real alpha, vector beta, real sigma); 
 normal_id_glm_lpdf; (vector y | matrix x, vector alpha, vector beta, real sigma); real
 normal_id_glm_lpdf; (vector y | row_vector x, real alpha, vector beta, real sigma); real
 normal_id_glm_lpdf; (vector y | row_vector x, vector alpha, vector beta, real sigma); real
+normal_id_glm_lupdf; (real y | matrix x, real alpha, vector beta, real sigma); real
+normal_id_glm_lupdf; (real y | matrix x, vector alpha, vector beta, real sigma); real
+normal_id_glm_lupdf; (vector y | matrix x, real alpha, vector beta, real sigma); real
+normal_id_glm_lupdf; (vector y | matrix x, vector alpha, vector beta, real sigma); real
+normal_id_glm_lupdf; (vector y | row_vector x, real alpha, vector beta, real sigma); real
+normal_id_glm_lupdf; (vector y | row_vector x, vector alpha, vector beta, real sigma); real
 normal_lccdf; (reals y | reals mu, reals sigma); real
 normal_lcdf; (reals y | reals mu, reals sigma); real
 normal_lpdf; (reals y | reals mu, reals sigma); real
+normal_lupdf; (reals y | reals mu, reals sigma); real
 normal_rng; (reals mu, reals sigma); R
-not_a_number; ~; real
-num_elements; (T[] x); int
+not_a_number; (); real
+num_elements; (array[] T x); int
 num_elements; (matrix x); int
 num_elements; (row_vector x); int
 num_elements; (vector x); int
+ode_adams; (function ode, vector initial_state, real initial_time, array[] real times, ...); array[] vector
+ode_adams_tol; (function ode, vector initial_state, real initial_time, array[] real times, data real rel_tol, data real abs_tol, int max_num_steps, ...); array[] vector
+ode_adjoint_tol_ctl; (function ode, vector initial_state, real initial_time, array[] real times, data real rel_tol_forward, data vector abs_tol_forward, data real rel_tol_backward, data vector abs_tol_backward, data real rel_tol_quadrature, data real abs_tol_qudrature, int max_num_steps, int num_steps_between_checkpoints, int interpolation_polynomial, int solver_forward, int solver_backward,...); array[] vector
+ode_bdf; (function ode, vector initial_state, real initial_time, array[] real times, ...); array[] vector
+ode_bdf_tol; (function ode, vector initial_state, real initial_time, array[] real times, data real rel_tol, data real abs_tol, int max_num_steps, ...); array[] vector
+ode_ckrk; (function ode, vector initial_state, real initial_time, array[] real times, ...); array[] vector
+ode_ckrk_tol; (function ode, vector initial_state, real initial_time, array[] real times, data real rel_tol, data real abs_tol, int max_num_steps, ...); array[] vector
+ode_rk45; (function ode, vector initial_state, real initial_time, array[] real times, ...); array[] vector
+ode_rk45_tol; (function ode, vector initial_state, real initial_time, array[] real times, data real rel_tol, data real abs_tol, int max_num_steps, ...); array[] vector
+one_hot_array; (int n, int k); array[] real
+one_hot_int_array; (int n, int k); array[] int
+one_hot_row_vector; (int n, int k); row_vector
+one_hot_vector; (int K, int k); vector
+ones_array; (int n); array[] real
+ones_int_array; (int n); array[] int
+ones_row_vector; (int n); row_vector
+ones_vector; (int n); vector
 operator!; (int x); int
 operator!; (real x); int
+operator!=; (complex x, complex y); int
 operator!=; (int x, int y); int
 operator!=; (real x, real y); int
+operator%/%; (int x, int y); int
 operator%; (int x, int y); int
 operator&&; (int x, int y); int
 operator&&; (real x, real y); int
 operator'; (matrix x); matrix
 operator'; (row_vector x); vector
 operator'; (vector x); row_vector
+operator*; (complex x, complex y); complex
 operator*; (int x, int y); int
 operator*; (matrix x, matrix y); matrix
 operator*; (matrix x, real y); matrix
@@ -431,6 +598,7 @@ operator*; (row_vector x, real y); row_vector
 operator*; (row_vector x, vector y); real
 operator*; (vector x, real y); vector
 operator*; (vector x, row_vector y); matrix
+operator*=; (complex x, complex y); void
 operator*=; (int x, int y); void
 operator*=; (matrix x, matrix y); void
 operator*=; (matrix x, real y); void
@@ -438,6 +606,8 @@ operator*=; (real x, real y); void
 operator*=; (row_vector x, matrix y); void
 operator*=; (row_vector x, real y); void
 operator*=; (vector x, real y); void
+operator+; (complex x, complex y); complex
+operator+; (complex z); complex
 operator+; (int x); int
 operator+; (int x, int y); int
 operator+; (matrix x, matrix y); matrix
@@ -451,6 +621,7 @@ operator+; (row_vector x, real y); row_vector
 operator+; (row_vector x, row_vector y); row_vector
 operator+; (vector x, real y); vector
 operator+; (vector x, vector y); vector
+operator+=; (complex x, complex y); void
 operator+=; (int x, int y); void
 operator+=; (matrix x, matrix y); void
 operator+=; (matrix x, real y); void
@@ -459,6 +630,8 @@ operator+=; (row_vector x, real y); void
 operator+=; (row_vector x, row_vector y); void
 operator+=; (vector x, real y); void
 operator+=; (vector x, vector y); void
+operator-; (complex x, complex y); complex
+operator-; (complex z); complex
 operator-; (int x); int
 operator-; (int x, int y); int
 operator-; (matrix x); matrix
@@ -475,6 +648,7 @@ operator-; (row_vector x, row_vector y); row_vector
 operator-; (vector x); vector
 operator-; (vector x, real y); vector
 operator-; (vector x, vector y); vector
+operator-=; (complex x, complex y); void
 operator-=; (int x, int y); void
 operator-=; (matrix x, matrix y); void
 operator-=; (matrix x, real y); void
@@ -513,6 +687,7 @@ operator.^; (row_vector x, real y); row_vector
 operator.^; (row_vector x, row_vector y); row_vector
 operator.^; (vector x, real y); vector
 operator.^; (vector x, vector y); vector
+operator/; (complex x, complex y); complex
 operator/; (int x, int y); int
 operator/; (matrix B, matrix A); matrix
 operator/; (matrix x, real y); matrix
@@ -520,6 +695,7 @@ operator/; (real x, real y); real
 operator/; (row_vector b, matrix A); row_vector
 operator/; (row_vector x, real y); row_vector
 operator/; (vector x, real y); vector
+operator/=; (complex x, complex y); void
 operator/=; (int x, int y); void
 operator/=; (matrix x, real y); void
 operator/=; (real x, real y); void
@@ -529,6 +705,8 @@ operator<; (int x, int y); int
 operator<; (real x, real y); int
 operator<=; (int x, int y); int
 operator<=; (real x, real y); int
+operator=; (complex x, complex y); void
+operator==; (complex x, complex y); int
 operator==; (int x, int y); int
 operator==; (real x, real y); int
 operator>; (int x, int y); int
@@ -537,57 +715,79 @@ operator>=; (int x, int y); int
 operator>=; (real x, real y); int
 operator\; (matrix A, matrix B); matrix
 operator\; (matrix A, vector b); vector
+operator^; (complex x, complex y); complex
 operator^; (real x, real y); real
 operator||; (int x, int y); int
 operator||; (real x, real y); int
 ordered_logistic; ~; real
+ordered_logistic_glm_lpmf; (array[] int y | matrix x, vector beta, vector c); real
+ordered_logistic_glm_lpmf; (array[] int y | row_vector x, vector beta, vector c); real
 ordered_logistic_glm_lpmf; (int y | matrix x, vector beta, vector c); real
 ordered_logistic_glm_lpmf; (int y | row_vector x, vector beta, vector c); real
-ordered_logistic_glm_lpmf; (int[] y | matrix x, vector beta, vector c); real
-ordered_logistic_glm_lpmf; (int[] y | row_vector x, vector beta, vector c); real
+ordered_logistic_glm_lupmf; (array[] int y | matrix x, vector beta, vector c); real
+ordered_logistic_glm_lupmf; (array[] int y | row_vector x, vector beta, vector c); real
+ordered_logistic_glm_lupmf; (int y | matrix x, vector beta, vector c); real
+ordered_logistic_glm_lupmf; (int y | row_vector x, vector beta, vector c); real
 ordered_logistic_lpmf; (ints k | vector eta, vectors c); real
+ordered_logistic_lupmf; (ints k | vector eta, vectors c); real
 ordered_logistic_rng; (real eta, vector c); int
 ordered_probit; ~; real
 ordered_probit_lpmf; (ints k | vector eta, vectors c); real
+ordered_probit_lupmf; (ints k | vector eta, vectors c); real
 ordered_probit_rng; (real eta, vector c); int
+owens_t; (T1 x, T2 y); R
 owens_t; (real h, real a); real
 pareto; ~; real
 pareto_cdf; (reals y, reals y_min, reals alpha); real
 pareto_lccdf; (reals y | reals y_min, reals alpha); real
 pareto_lcdf; (reals y | reals y_min, reals alpha); real
 pareto_lpdf; (reals y | reals y_min, reals alpha); real
+pareto_lupdf; (reals y | reals y_min, reals alpha); real
 pareto_rng; (reals y_min, reals alpha); R
 pareto_type_2; ~; real
 pareto_type_2_cdf; (reals y, reals mu, reals lambda, reals alpha); real
 pareto_type_2_lccdf; (reals y | reals mu, reals lambda, reals alpha); real
 pareto_type_2_lcdf; (reals y | reals mu, reals lambda, reals alpha); real
 pareto_type_2_lpdf; (reals y | reals mu, reals lambda, reals alpha); real
+pareto_type_2_lupdf; (reals y | reals mu, reals lambda, reals alpha); real
 pareto_type_2_rng; (reals mu, reals lambda, reals alpha); R
-pi; ~; real
+pi; (); real
 poisson; ~; real
 poisson_cdf; (ints n, reals lambda); real
 poisson_lccdf; (ints n | reals lambda); real
 poisson_lcdf; (ints n | reals lambda); real
 poisson_log; ~; real
 poisson_log_glm; ~; real
+poisson_log_glm_lpmf; (array[] int y | matrix x, real alpha, vector beta); real
+poisson_log_glm_lpmf; (array[] int y | matrix x, vector alpha, vector beta); real
+poisson_log_glm_lpmf; (array[] int y | row_vector x, real alpha, vector beta); real
+poisson_log_glm_lpmf; (array[] int y | row_vector x, vector alpha, vector beta); real
 poisson_log_glm_lpmf; (int y | matrix x, real alpha, vector beta); real
 poisson_log_glm_lpmf; (int y | matrix x, vector alpha, vector beta); real
-poisson_log_glm_lpmf; (int[] y | matrix x, real alpha, vector beta); real
-poisson_log_glm_lpmf; (int[] y | matrix x, vector alpha, vector beta); real
-poisson_log_glm_lpmf; (int[] y | row_vector x, real alpha, vector beta); real
-poisson_log_glm_lpmf; (int[] y | row_vector x, vector alpha, vector beta); real
+poisson_log_glm_lupmf; (array[] int y | matrix x, real alpha, vector beta); real
+poisson_log_glm_lupmf; (array[] int y | matrix x, vector alpha, vector beta); real
+poisson_log_glm_lupmf; (array[] int y | row_vector x, real alpha, vector beta); real
+poisson_log_glm_lupmf; (array[] int y | row_vector x, vector alpha, vector beta); real
+poisson_log_glm_lupmf; (int y | matrix x, real alpha, vector beta); real
+poisson_log_glm_lupmf; (int y | matrix x, vector alpha, vector beta); real
 poisson_log_lpmf; (ints n | reals alpha); real
+poisson_log_lupmf; (ints n | reals alpha); real
 poisson_log_rng; (reals alpha); R
 poisson_lpmf; (ints n | reals lambda); real
+poisson_lupmf; (ints n | reals lambda); real
 poisson_rng; (reals lambda); R
-positive_infinity; ~; real
+polar; (real r, real theta); complex
+positive_infinity; (); real
+pow; (T1 x, T2 y); R
+pow; (complex x, complex y); complex
 pow; (real x, real y); real
 print; (T1 x1,..., TN xN); void
-prod; (int[] x); real
+prod; (array[] int x); real
+prod; (array[] real x); real
 prod; (matrix x); real
-prod; (real[] x); real
 prod; (row_vector x); real
 prod; (vector x); real
+proj; (complex z); complex
 qr_Q; (matrix A); matrix
 qr_R; (matrix A); matrix
 qr_thin_Q; (matrix A); matrix
@@ -598,8 +798,14 @@ quad_form_diag; (matrix m, row_vector rv); matrix
 quad_form_diag; (matrix m, vector v); matrix
 quad_form_sym; (matrix A, matrix B); matrix
 quad_form_sym; (matrix A, vector B); real
-rank; (int[] v, int s); int
-rank; (real[] v, int s); int
+quantile; (data array[] real x, data array[] real p); array[] real
+quantile; (data array[] real x, data real p); real
+quantile; (data row_vector x, data array[] real p); array[] real
+quantile; (data row_vector x, data real p); real
+quantile; (data vector x, data array[] real p); array[] real
+quantile; (data vector x, data real p); real
+rank; (array[] int v, int s); int
+rank; (array[] real v, int s); int
 rank; (row_vector v, int s); int
 rank; (vector v, int s); int
 rayleigh; ~; real
@@ -607,20 +813,22 @@ rayleigh_cdf; (real y, real sigma); real
 rayleigh_lccdf; (real y | real sigma); real
 rayleigh_lcdf; (real y | real sigma); real
 rayleigh_lpdf; (reals y | reals sigma); real
+rayleigh_lupdf; (reals y | reals sigma); real
 rayleigh_rng; (reals sigma); R
-reduce_sum; (F f, T[] x, int grainsize, T1 s1, T2 s2, ...); real
+reduce_sum; (F f, array[] T x, int grainsize, T1 s1, T2 s2, ...); real
 reject; (T1 x1,..., TN xN); void
-rep_array; (T x, int k, int m, int n); T[,,]
-rep_array; (T x, int m, int n); T[,]
-rep_array; (T x, int n); T[]
+rep_array; (T x, int k, int m, int n); array[,,] T
+rep_array; (T x, int m, int n); array[,] T
+rep_array; (T x, int n); array[] T
 rep_matrix; (real x, int m, int n); matrix
 rep_matrix; (row_vector rv, int m); matrix
 rep_matrix; (vector v, int n); matrix
 rep_row_vector; (real x, int n); row_vector
 rep_vector; (real x, int m); vector
-reverse; (T[] v); T[]
+reverse; (array[] T v); array[] T
 reverse; (row_vector v); row_vector
 reverse; (vector v); vector
+rising_factorial; (T1 x, T2 y); R
 rising_factorial; (real x, int n); real
 round; (T x); R
 row; (matrix x, int m); row_vector
@@ -639,53 +847,71 @@ scaled_inv_chi_square_cdf; (reals y, reals nu, reals sigma); real
 scaled_inv_chi_square_lccdf; (reals y | reals nu, reals sigma); real
 scaled_inv_chi_square_lcdf; (reals y | reals nu, reals sigma); real
 scaled_inv_chi_square_lpdf; (reals y | reals nu, reals sigma); real
+scaled_inv_chi_square_lupdf; (reals y | reals nu, reals sigma); real
 scaled_inv_chi_square_rng; (reals nu, reals sigma); R
+sd; (array[] real x); real
 sd; (matrix x); real
-sd; (real[] x); real
 sd; (row_vector x); real
 sd; (vector x); real
-segment; (T[] sv, int i, int n); T[]
+segment; (array[] T sv, int i, int n); array[] T
 segment; (row_vector rv, int i, int n); row_vector
 segment; (vector v, int i, int n); vector
 sin; (T x); R
+sin; (complex z); complex
 singular_values; (matrix A); vector
 sinh; (T x); R
-size; (T[] x); int
+sinh; (complex z); complex
+size; (array[] T x); int
+size; (int x); int
+size; (matrix x); int
+size; (real x); int
+size; (row_vector x); int
+size; (vector x); int
+skew_double_exponential; ~; real
+skew_double_exponential_cdf; (reals y, reals mu, reals sigma, reals tau); real
+skew_double_exponential_lccdf; (reals y | reals mu, reals sigma, reals tau); real
+skew_double_exponential_lcdf; (reals y | reals mu, reals sigma, reals tau); real
+skew_double_exponential_lpdf; (reals y | reals mu, reals sigma, reals tau); real
+skew_double_exponential_lupdf; (reals y | reals mu, reals sigma, reals tau); real
+skew_double_exponential_rng; (reals mu, reals sigma); R
 skew_normal; ~; real
 skew_normal_cdf; (reals y, reals xi, reals omega, reals alpha); real
 skew_normal_lccdf; (reals y | reals xi, reals omega, reals alpha); real
 skew_normal_lcdf; (reals y | reals xi, reals omega, reals alpha); real
 skew_normal_lpdf; (reals y | reals xi, reals omega, reals alpha); real
+skew_normal_lupdf; (reals y | reals xi, reals omega, reals alpha); real
 skew_normal_rng; (reals xi, reals omega, real alpha); R
 softmax; (vector x); vector
-sort_asc; (int[] v); int[]
-sort_asc; (real[] v); real[]
+sort_asc; (array[] int v); array[] int
+sort_asc; (array[] real v); array[] real
 sort_asc; (row_vector v); row_vector
 sort_asc; (vector v); vector
-sort_desc; (int[] v); int[]
-sort_desc; (real[] v); real[]
+sort_desc; (array[] int v); array[] int
+sort_desc; (array[] real v); array[] real
 sort_desc; (row_vector v); row_vector
 sort_desc; (vector v); vector
-sort_indices_asc; (int[] v); int[]
-sort_indices_asc; (real[] v); int[]
-sort_indices_asc; (row_vector v); int[]
-sort_indices_asc; (vector v); int[]
-sort_indices_desc; (int[] v); int[]
-sort_indices_desc; (real[] v); int[]
-sort_indices_desc; (row_vector v); int[]
-sort_indices_desc; (vector v); int[]
-sqrt2; ~; real
+sort_indices_asc; (array[] int v); array[] int
+sort_indices_asc; (array[] real v); array[] int
+sort_indices_asc; (row_vector v); array[] int
+sort_indices_asc; (vector v); array[] int
+sort_indices_desc; (array[] int v); array[] int
+sort_indices_desc; (array[] real v); array[] int
+sort_indices_desc; (row_vector v); array[] int
+sort_indices_desc; (vector v); array[] int
+sqrt2; (); real
 sqrt; (T x); R
+sqrt; (complex x); complex
 square; (T x); R
-squared_distance; (row_vector x, row_vector[] y); real
-squared_distance; (row_vector x, vector[] y); real
-squared_distance; (vector x, row_vector[] y); real
+squared_distance; (row_vector x, row_vector y); real
+squared_distance; (row_vector x, vector y); real
+squared_distance; (vector x, row_vector y); real
 squared_distance; (vector x, vector y); real
 std_normal; ~; real
 std_normal_cdf; (reals y); real
 std_normal_lccdf; (reals y); real
 std_normal_lcdf; (reals y); real
 std_normal_lpdf; (reals y); real
+std_normal_lupdf; (reals y); real
 std_normal_rng; (); real
 step; (real x); real
 student_t; ~; real
@@ -693,51 +919,60 @@ student_t_cdf; (reals y, reals nu, reals mu, reals sigma); real
 student_t_lccdf; (reals y | reals nu, reals mu, reals sigma); real
 student_t_lcdf; (reals y | reals nu, reals mu, reals sigma); real
 student_t_lpdf; (reals y | reals nu, reals mu, reals sigma); real
+student_t_lupdf; (reals y | reals nu, reals mu, reals sigma); real
 student_t_rng; (reals nu, reals mu, reals sigma); R
 sub_col; (matrix x, int i, int j, int n_rows); vector
 sub_row; (matrix x, int i, int j, int n_cols); row_vector
-sum; (int[] x); int
+sum; (array[] int x); int
+sum; (array[] real x); real
 sum; (matrix x); real
-sum; (real[] x); real
 sum; (row_vector x); real
 sum; (vector x); real
-tail; (T[] sv, int n); T[]
+svd_U; (matrix A); vector
+svd_V; (matrix A); vector
+symmetrize_from_lower_tri; (matrix A); matrix
+tail; (array[] T sv, int n); array[] T
 tail; (row_vector rv, int n); row_vector
 tail; (vector v, int n); vector
 tan; (T x); R
+tan; (complex z); complex
 tanh; (T x); R
-target; ~; real
+tanh; (complex z); complex
+target; (); real
 tcrossprod; (matrix x); matrix
 tgamma; (T x); R
-to_array_1d; (int[...] a); int[]
-to_array_1d; (matrix m); real[]
-to_array_1d; (real[...] a); real[]
-to_array_1d; (row_vector v); real[]
-to_array_1d; (vector v); real[]
-to_array_2d; (matrix m); real[,]
-to_matrix; (int[,] a); matrix
-to_matrix; (int[] a, int m, int n); matrix
-to_matrix; (int[] a, int m, int n, int col_major); matrix
+to_array_1d; (array[...] int a); array[] int
+to_array_1d; (array[...] real a); array[] real
+to_array_1d; (matrix m); array[] real
+to_array_1d; (row_vector v); array[] real
+to_array_1d; (vector v); array[] real
+to_array_2d; (matrix m); array[,] real
+to_complex; (); complex
+to_complex; (real re); complex
+to_complex; (real re, real im); complex
+to_matrix; (array[,] int a); matrix
+to_matrix; (array[,] real a); matrix
+to_matrix; (array[] int a, int m, int n); matrix
+to_matrix; (array[] int a, int m, int n, int col_major); matrix
+to_matrix; (array[] real a, int m, int n); matrix
+to_matrix; (array[] real a, int m, int n, int col_major); matrix
 to_matrix; (matrix m); matrix
 to_matrix; (matrix m, int m, int n); matrix
 to_matrix; (matrix m, int m, int n, int col_major); matrix
-to_matrix; (real[,] a); matrix
-to_matrix; (real[] a, int m, int n); matrix
-to_matrix; (real[] a, int m, int n, int col_major); matrix
 to_matrix; (row_vector v); matrix
 to_matrix; (row_vector v, int m, int n); matrix
 to_matrix; (row_vector v, int m, int n, int col_major); matrix
 to_matrix; (vector v); matrix
 to_matrix; (vector v, int m, int n); matrix
 to_matrix; (vector v, int m, int n, int col_major); matrix
-to_row_vector; (int[] a); row_vector
+to_row_vector; (array[] int a); row_vector
+to_row_vector; (array[] real a); row_vector
 to_row_vector; (matrix m); row_vector
-to_row_vector; (real[] a); row_vector
 to_row_vector; (row_vector v); row_vector
 to_row_vector; (vector v); row_vector
-to_vector; (int[] a); vector
+to_vector; (array[] int a); vector
+to_vector; (array[] real a); vector
 to_vector; (matrix m); vector
-to_vector; (real[] a); vector
 to_vector; (row_vector v); vector
 to_vector; (vector v); vector
 trace; (matrix A); real
@@ -750,22 +985,32 @@ uniform_cdf; (reals y, reals alpha, reals beta); real
 uniform_lccdf; (reals y | reals alpha, reals beta); real
 uniform_lcdf; (reals y | reals alpha, reals beta); real
 uniform_lpdf; (reals y | reals alpha, reals beta); real
+uniform_lupdf; (reals y | reals alpha, reals beta); real
 uniform_rng; (reals alpha, reals beta); R
+uniform_simplex; (int n); vector
+variance; (array[] real x); real
 variance; (matrix x); real
-variance; (real[] x); real
 variance; (row_vector x); real
 variance; (vector x); real
 von_mises; ~; real
 von_mises_lpdf; (reals y | reals mu, reals kappa); R
+von_mises_lupdf; (reals y | reals mu, reals kappa); R
 von_mises_rng; (reals mu, reals kappa); R
 weibull; ~; real
 weibull_cdf; (reals y, reals alpha, reals sigma); real
 weibull_lccdf; (reals y | reals alpha, reals sigma); real
 weibull_lcdf; (reals y | reals alpha, reals sigma); real
 weibull_lpdf; (reals y | reals alpha, reals sigma); real
+weibull_lupdf; (reals y | reals alpha, reals sigma); real
 weibull_rng; (reals alpha, reals sigma); R
 wiener; ~; real
 wiener_lpdf; (reals y | reals alpha, reals tau, reals beta, reals delta); real
+wiener_lupdf; (reals y | reals alpha, reals tau, reals beta, reals delta); real
 wishart; ~; real
 wishart_lpdf; (matrix W | real nu, matrix Sigma); real
+wishart_lupdf; (matrix W | real nu, matrix Sigma); real
 wishart_rng; (real nu, matrix Sigma); matrix
+zeros_array; (int n); array[] real
+zeros_int_array; (int n); array[] int
+zeros_row_vector; (int n); row_vector
+zeros_row_vector; (int n); vector

--- a/stan-lang-keywords.yaml
+++ b/stan-lang-keywords.yaml
@@ -1,18 +1,19 @@
 # These come from the sections of the Stan Reference Manual
-# - Ch. 6: Expressions (https://mc-stan.org/docs/2_24/reference-manual/expressions.html)
-# - Ch. 11: Language Syntax (https://mc-stan.org/docs/2_24/reference-manual/language-syntax.html)
-# - https://github.com/stan-dev/stan/blob/develop/src/stan/lang/grammars/statement_grammar_def.hpp (non-distribution functions ending in _log)
+# - Ch. 6: Expressions (https://mc-stan.org/docs/reference-manual/expressions.html)
+# - Ch. 11: Language Syntax (https://mc-stan.org/docs//reference-manual/language-syntax.html)
 
 types:
-  basic: # https://mc-stan.org/docs/2_24/reference-manual/type-inference.html
+  basic: # https://mc-stan.org/docs//reference-manual/type-inference.html
     - "int"
     - "real"
+    - "complex"
     - "vector"
     - "row_vector"
     - "matrix"
-  variable: # https://mc-stan.org/docs/2_24/reference-manual/type-inference.html (Primitive Type Table)
+  variable: # https://mc-stan.org/docs/reference-manual/type-inference.html (Primitive Type Table)
     - "int"
     - "real"
+    - "complex"
     - "matrix"
     - "cov_matrix"
     - "corr_matrix"
@@ -24,9 +25,10 @@ types:
     - "ordered"
     - "positive_ordered"
     - "row_vector"
-  return: # https://mc-stan.org/docs/2_24/stan-users-guide/basic-functions-section.html (Type Declarations for Functions)
+  return: # https://mc-stan.org/docs/stan-users-guide/basic-functions-section.html (Type Declarations for Functions)
     - "int"
     - "real"
+    - "complex"
     - "vector"
     - "row_vector"
     - "matrix"
@@ -56,14 +58,14 @@ keywords:
   other:
     - "return"
     - "target"
-    - "offset"
-    - "multiplier"
   functions:
     - "print"
     - "reject"
   range_constraints:
     - "lower"
     - "upper"
+    - "offset"
+    - "multiplier"
 
 special_variables : []
 
@@ -188,6 +190,12 @@ reserved:
   - else
   - "true"
   - "false"
+  - print
+  - reject
+  - profile
+  - get_lp
+  - increment_log_prob
+  - target
   - var
   - fvar
   - STAN_MAJOR
@@ -212,6 +220,8 @@ operators:
   - "/"
   - "%"
   - "\\"
+  - ".^"
+  - "%/%"
   - ".*"
   - "./"
   - "!"

--- a/stan_lang.json
+++ b/stan_lang.json
@@ -106,6 +106,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "real"
         }
       ]
     },
@@ -129,6 +138,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -152,6 +170,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -236,11 +263,11 @@
             },
             {
               "name": "x_r",
-              "type": "real[]"
+              "type": "data array[] real"
             },
             {
               "name": "x_i",
-              "type": "int[]"
+              "type": "array[] int"
             }
           ],
           "return": "vector"
@@ -261,19 +288,95 @@
             },
             {
               "name": "x_r",
-              "type": "real[]"
+              "type": "data array[] real"
             },
             {
               "name": "x_i",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "rel_tol",
-              "type": "real"
+              "type": "data real"
             },
             {
               "name": "f_tol",
-              "type": "real"
+              "type": "data real"
+            },
+            {
+              "name": "max_steps",
+              "type": "int"
+            }
+          ],
+          "return": "vector"
+        }
+      ]
+    },
+    "algebra_solver_newton": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "algebra_system",
+              "type": "function"
+            },
+            {
+              "name": "y_guess",
+              "type": "vector"
+            },
+            {
+              "name": "theta",
+              "type": "vector"
+            },
+            {
+              "name": "x_r",
+              "type": "data array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            }
+          ],
+          "return": "vector"
+        },
+        {
+          "args": [
+            {
+              "name": "algebra_system",
+              "type": "function"
+            },
+            {
+              "name": "y_guess",
+              "type": "vector"
+            },
+            {
+              "name": "theta",
+              "type": "vector"
+            },
+            {
+              "name": "x_r",
+              "type": "data array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            },
+            {
+              "name": "rel_tol",
+              "type": "data real"
+            },
+            {
+              "name": "f_tol",
+              "type": "data real"
             },
             {
               "name": "max_steps",
@@ -521,6 +624,29 @@
         }
       ]
     },
+    "arg": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "asin": {
       "density": false,
       "deprecated": false,
@@ -541,6 +667,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -564,6 +699,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -587,6 +731,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -637,6 +790,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -737,6 +899,90 @@
           "args": [
             {
               "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
               "type": "int"
             },
             {
@@ -774,12 +1020,26 @@
             }
           ],
           "return": "real"
-        },
+        }
+      ]
+    },
+    "bernoulli_logit_glm_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
         {
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -800,7 +1060,7 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -821,7 +1081,7 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -842,11 +1102,53 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
               "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
             },
             {
               "name": "alpha",
@@ -872,6 +1174,33 @@
       "math": false,
       "operator": false,
       "sampling": "bernoulli_logit",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "bernoulli_logit_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -938,6 +1267,33 @@
         }
       ]
     },
+    "bernoulli_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "theta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "bernoulli_rng": {
       "density": false,
       "deprecated": false,
@@ -976,6 +1332,19 @@
         {
           "args": [
             {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
               "name": "v",
               "type": "int"
             },
@@ -1003,11 +1372,64 @@
         {
           "args": [
             {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
               "name": "v",
               "type": "int"
             },
             {
               "name": "x",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "beta": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
               "type": "real"
             }
           ],
@@ -1131,6 +1553,41 @@
       "math": false,
       "operator": false,
       "sampling": "beta_binomial",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "N",
+              "type": "ints"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "beta_binomial_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -1310,6 +1767,37 @@
         }
       ]
     },
+    "beta_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "theta",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "beta_proportion_lccdf": {
       "density": false,
       "deprecated": false,
@@ -1441,6 +1929,19 @@
         {
           "args": [
             {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
               "name": "y",
               "type": "int"
             },
@@ -1496,6 +1997,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -1604,6 +2118,37 @@
         }
       ]
     },
+    "binomial_logit_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "N",
+              "type": "ints"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "binomial_lpmf": {
       "density": true,
       "deprecated": false,
@@ -1615,6 +2160,37 @@
       "math": false,
       "operator": false,
       "sampling": "binomial",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "N",
+              "type": "ints"
+            },
+            {
+              "name": "theta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "binomial_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -1717,6 +2293,19 @@
           "args": [
             {
               "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "theta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
               "type": "int"
             },
             {
@@ -1754,16 +2343,72 @@
             }
           ],
           "return": "real"
+        }
+      ]
+    },
+    "categorical_logit_glm_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "theta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
         },
         {
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "int"
             },
             {
-              "name": "theta",
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
               "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "matrix"
             }
           ],
           "return": "real"
@@ -1781,6 +2426,33 @@
       "math": false,
       "operator": false,
       "sampling": "categorical_logit",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "categorical_logit_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -1831,6 +2503,33 @@
       "math": false,
       "operator": false,
       "sampling": "categorical",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "theta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "categorical_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -1974,6 +2673,37 @@
       "math": false,
       "operator": false,
       "sampling": "cauchy",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "cauchy_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -2175,6 +2905,33 @@
         }
       ]
     },
+    "chi_square_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "nu",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "chi_square_rng": {
       "density": false,
       "deprecated": false,
@@ -2195,6 +2952,29 @@
             }
           ],
           "return": "R"
+        }
+      ]
+    },
+    "chol2inv": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "L",
+              "type": "matrix"
+            }
+          ],
+          "return": "matrix"
         }
       ]
     },
@@ -2233,6 +3013,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -2410,6 +3203,29 @@
         }
       ]
     },
+    "conj": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        }
+      ]
+    },
     "cos": {
       "density": false,
       "deprecated": false,
@@ -2430,6 +3246,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -2453,6 +3278,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -2472,7 +3306,7 @@
           "args": [
             {
               "name": "x",
-              "type": "real[]"
+              "type": "array[] real"
             },
             {
               "name": "alpha",
@@ -2489,11 +3323,11 @@
           "args": [
             {
               "name": "x1",
-              "type": "real[]"
+              "type": "array[] real"
             },
             {
               "name": "x2",
-              "type": "real[]"
+              "type": "array[] real"
             },
             {
               "name": "alpha",
@@ -2626,7 +3460,7 @@
               "type": "matrix"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         }
       ]
     },
@@ -2649,7 +3483,7 @@
               "type": "matrix"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         }
       ]
     },
@@ -2704,11 +3538,11 @@
             },
             {
               "name": "v",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "u",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "b",
@@ -2747,11 +3581,11 @@
             },
             {
               "name": "v",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "u",
-              "type": "int[]"
+              "type": "array[] int"
             }
           ],
           "return": "matrix"
@@ -2774,10 +3608,10 @@
           "args": [
             {
               "name": "x",
-              "type": "real[]"
+              "type": "array[] real"
             }
           ],
-          "return": "real[]"
+          "return": "array[] real"
         },
         {
           "args": [
@@ -2990,7 +3824,7 @@
               "type": "T"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         }
       ]
     },
@@ -3005,6 +3839,33 @@
       "math": false,
       "operator": false,
       "sampling": "dirichlet",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "theta",
+              "type": "vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "dirichlet_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -3041,6 +3902,188 @@
             }
           ],
           "return": "vector"
+        }
+      ]
+    },
+    "discrete_range_cdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "l",
+              "type": "ints"
+            },
+            {
+              "name": "u",
+              "type": "ints"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "discrete_range_lccdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": true,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": false,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "l",
+              "type": "ints"
+            },
+            {
+              "name": "u",
+              "type": "ints"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "discrete_range_lcdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": true,
+      "lpdf": false,
+      "lpmf": false,
+      "math": false,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "l",
+              "type": "ints"
+            },
+            {
+              "name": "u",
+              "type": "ints"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "discrete_range_lpmf": {
+      "density": true,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": true,
+      "math": false,
+      "operator": false,
+      "sampling": "discrete_range",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "l",
+              "type": "ints"
+            },
+            {
+              "name": "u",
+              "type": "ints"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "discrete_range_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "ints"
+            },
+            {
+              "name": "l",
+              "type": "ints"
+            },
+            {
+              "name": "u",
+              "type": "ints"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "discrete_range_rng": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "l",
+              "type": "ints"
+            },
+            {
+              "name": "u",
+              "type": "ints"
+            }
+          ],
+          "return": "int"
         }
       ]
     },
@@ -3332,6 +4375,37 @@
         }
       ]
     },
+    "double_exponential_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "double_exponential_rng": {
       "density": false,
       "deprecated": false,
@@ -3356,6 +4430,24 @@
             }
           ],
           "return": "R"
+        }
+      ]
+    },
+    "e": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
         }
       ]
     },
@@ -3471,6 +4563,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -3613,6 +4714,41 @@
       "math": false,
       "operator": false,
       "sampling": "exp_mod_normal",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            },
+            {
+              "name": "lambda",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "exp_mod_normal_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -3799,6 +4935,33 @@
         }
       ]
     },
+    "exponential_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "exponential_rng": {
       "density": false,
       "deprecated": false,
@@ -3861,6 +5024,19 @@
           "args": [
             {
               "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "real"
             },
             {
@@ -3884,6 +5060,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -3969,6 +5158,19 @@
           "args": [
             {
               "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "real"
             },
             {
@@ -3996,6 +5198,19 @@
           "args": [
             {
               "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "real"
             },
             {
@@ -4019,6 +5234,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -4138,6 +5366,37 @@
       "math": false,
       "operator": false,
       "sampling": "frechet",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "frechet_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -4309,6 +5568,37 @@
         }
       ]
     },
+    "gamma_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "gamma_p": {
       "density": false,
       "deprecated": false,
@@ -4321,6 +5611,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -4348,6 +5651,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -4464,6 +5780,173 @@
             {
               "name": "C0",
               "type": "matrix"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "gaussian_dlm_obs_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "matrix"
+            },
+            {
+              "name": "F",
+              "type": "matrix"
+            },
+            {
+              "name": "G",
+              "type": "matrix"
+            },
+            {
+              "name": "V",
+              "type": "matrix"
+            },
+            {
+              "name": "W",
+              "type": "matrix"
+            },
+            {
+              "name": "m0",
+              "type": "vector"
+            },
+            {
+              "name": "C0",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "matrix"
+            },
+            {
+              "name": "F",
+              "type": "matrix"
+            },
+            {
+              "name": "G",
+              "type": "matrix"
+            },
+            {
+              "name": "V",
+              "type": "vector"
+            },
+            {
+              "name": "W",
+              "type": "matrix"
+            },
+            {
+              "name": "m0",
+              "type": "vector"
+            },
+            {
+              "name": "C0",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "generalized_inverse": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "A",
+              "type": "matrix"
+            }
+          ],
+          "return": "matrix"
+        }
+      ]
+    },
+    "get_imag": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "get_lp": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
+        }
+      ]
+    },
+    "get_real": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
             }
           ],
           "return": "real"
@@ -4594,6 +6077,37 @@
         }
       ]
     },
+    "gumbel_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "gumbel_rng": {
       "density": false,
       "deprecated": false,
@@ -4637,14 +6151,14 @@
           "args": [
             {
               "name": "sv",
-              "type": "T[]"
+              "type": "array[] T"
             },
             {
               "name": "n",
               "type": "int"
             }
           ],
-          "return": "T[]"
+          "return": "array[] T"
         },
         {
           "args": [
@@ -4674,6 +6188,99 @@
         }
       ]
     },
+    "hmm_hidden_state_prob": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "log_omega",
+              "type": "matrix"
+            },
+            {
+              "name": "Gamma",
+              "type": "matrix"
+            },
+            {
+              "name": "rho",
+              "type": "vector"
+            }
+          ],
+          "return": "matrix"
+        }
+      ]
+    },
+    "hmm_latent_rng": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "log_omega",
+              "type": "matrix"
+            },
+            {
+              "name": "Gamma",
+              "type": "matrix"
+            },
+            {
+              "name": "rho",
+              "type": "vector"
+            }
+          ],
+          "return": "array[] int"
+        }
+      ]
+    },
+    "hmm_marginal": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "log_omega",
+              "type": "matrix"
+            },
+            {
+              "name": "Gamma",
+              "type": "matrix"
+            },
+            {
+              "name": "rho",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "hypergeometric_lpmf": {
       "density": true,
       "deprecated": false,
@@ -4685,6 +6292,41 @@
       "math": false,
       "operator": false,
       "sampling": "hypergeometric",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "N",
+              "type": "int"
+            },
+            {
+              "name": "a",
+              "type": "int"
+            },
+            {
+              "name": "b",
+              "type": "int"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "hypergeometric_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -4756,6 +6398,19 @@
           "args": [
             {
               "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "real"
             },
             {
@@ -4764,6 +6419,29 @@
             }
           ],
           "return": "real"
+        }
+      ]
+    },
+    "identity_matrix": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "k",
+              "type": "int"
+            }
+          ],
+          "return": "matrix"
         }
       ]
     },
@@ -4858,15 +6536,15 @@
             },
             {
               "name": "theta",
-              "type": "real[]"
+              "type": "array[] real"
             },
             {
               "name": "x_r",
-              "type": "real[]"
+              "type": "array[] real"
             },
             {
               "name": "x_i",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "relative_tolerance",
@@ -4891,18 +6569,341 @@
             },
             {
               "name": "theta",
-              "type": "real[]"
+              "type": "array[] real"
             },
             {
               "name": "x_r",
-              "type": "real[]"
+              "type": "array[] real"
             },
             {
               "name": "x_i",
-              "type": "int[]"
+              "type": "array[] int"
             }
           ],
           "return": "real"
+        }
+      ]
+    },
+    "integrate_ode": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "array[] real"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "theta",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_r",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            }
+          ],
+          "return": "array[,] real"
+        }
+      ]
+    },
+    "integrate_ode_adams": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "array[] real"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "theta",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_r",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            }
+          ],
+          "return": "array[,] real"
+        },
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "array[] real"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "theta",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_r",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            },
+            {
+              "name": "rel_tol",
+              "type": "real"
+            },
+            {
+              "name": "abs_tol",
+              "type": "real"
+            },
+            {
+              "name": "max_num_steps",
+              "type": "int"
+            }
+          ],
+          "return": "array[,] real"
+        }
+      ]
+    },
+    "integrate_ode_bdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "array[] real"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "theta",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_r",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            }
+          ],
+          "return": "array[,] real"
+        },
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "array[] real"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "theta",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_r",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            },
+            {
+              "name": "rel_tol",
+              "type": "real"
+            },
+            {
+              "name": "abs_tol",
+              "type": "real"
+            },
+            {
+              "name": "max_num_steps",
+              "type": "int"
+            }
+          ],
+          "return": "array[,] real"
+        }
+      ]
+    },
+    "integrate_ode_rk45": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "array[] real"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "theta",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_r",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            }
+          ],
+          "return": "array[,] real"
+        },
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "array[] real"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "theta",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_r",
+              "type": "array[] real"
+            },
+            {
+              "name": "x_i",
+              "type": "array[] int"
+            },
+            {
+              "name": "rel_tol",
+              "type": "real"
+            },
+            {
+              "name": "abs_tol",
+              "type": "real"
+            },
+            {
+              "name": "max_num_steps",
+              "type": "int"
+            }
+          ],
+          "return": "array[,] real"
         }
       ]
     },
@@ -5044,6 +7045,33 @@
       "math": false,
       "operator": false,
       "sampling": "inv_chi_square",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "nu",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "inv_chi_square_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -5230,6 +7258,37 @@
         }
       ]
     },
+    "inv_gamma_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "inv_gamma_rng": {
       "density": false,
       "deprecated": false,
@@ -5337,6 +7396,37 @@
       "math": false,
       "operator": false,
       "sampling": "inv_wishart",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "W",
+              "type": "matrix"
+            },
+            {
+              "name": "nu",
+              "type": "real"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "inv_wishart_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -5476,6 +7566,52 @@
         }
       ]
     },
+    "lambert_w0": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "reals"
+            }
+          ],
+          "return": "R"
+        }
+      ]
+    },
+    "lambert_wm1": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T"
+            }
+          ],
+          "return": "R"
+        }
+      ]
+    },
     "lbeta": {
       "density": false,
       "deprecated": false,
@@ -5488,6 +7624,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -5519,11 +7668,64 @@
           "args": [
             {
               "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "real"
             },
             {
               "name": "y",
               "type": "real"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "ldexp": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "real"
+            },
+            {
+              "name": "y",
+              "type": "int"
             }
           ],
           "return": "real"
@@ -5553,6 +7755,130 @@
         }
       ]
     },
+    "linspaced_array": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "lower",
+              "type": "data real"
+            },
+            {
+              "name": "upper",
+              "type": "data real"
+            }
+          ],
+          "return": "array[] real"
+        }
+      ]
+    },
+    "linspaced_int_array": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "lower",
+              "type": "int"
+            },
+            {
+              "name": "upper",
+              "type": "int"
+            }
+          ],
+          "return": "array[] real"
+        }
+      ]
+    },
+    "linspaced_row_vector": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "lower",
+              "type": "data real"
+            },
+            {
+              "name": "upper",
+              "type": "data real"
+            }
+          ],
+          "return": "row_vector"
+        }
+      ]
+    },
+    "linspaced_vector": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "lower",
+              "type": "data real"
+            },
+            {
+              "name": "upper",
+              "type": "data real"
+            }
+          ],
+          "return": "vector"
+        }
+      ]
+    },
     "lkj_corr_cholesky_lpdf": {
       "density": true,
       "deprecated": false,
@@ -5564,6 +7890,33 @@
       "math": false,
       "operator": false,
       "sampling": "lkj_corr_cholesky",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "L",
+              "type": "matrix"
+            },
+            {
+              "name": "eta",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "lkj_corr_cholesky_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -5634,6 +7987,33 @@
         }
       ]
     },
+    "lkj_corr_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "matrix"
+            },
+            {
+              "name": "eta",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "lkj_corr_rng": {
       "density": false,
       "deprecated": false,
@@ -5676,6 +8056,19 @@
         {
           "args": [
             {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
               "name": "n",
               "type": "int"
             },
@@ -5700,6 +8093,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -5735,6 +8141,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -5751,6 +8166,10 @@
       "sampling": null,
       "signatures": [
         {
+          "args": [],
+          "return": "real"
+        },
+        {
           "args": [
             {
               "name": "x",
@@ -5758,6 +8177,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -5889,6 +8317,10 @@
       "sampling": null,
       "signatures": [
         {
+          "args": [],
+          "return": "real"
+        },
+        {
           "args": [
             {
               "name": "x",
@@ -5934,6 +8366,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -5999,6 +8444,33 @@
         }
       ]
     },
+    "log_inv_logit_diff": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        }
+      ]
+    },
     "log_mix": {
       "density": false,
       "deprecated": false,
@@ -6030,6 +8502,46 @@
         }
       ]
     },
+    "log_modified_bessel_first_kind": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "v",
+              "type": "real"
+            },
+            {
+              "name": "z",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "log_rising_factorial": {
       "density": false,
       "deprecated": false,
@@ -6042,6 +8554,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -6096,6 +8621,15 @@
           "args": [
             {
               "name": "x",
+              "type": "array[] real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "matrix"
             }
           ],
@@ -6110,15 +8644,6 @@
             {
               "name": "y",
               "type": "real"
-            }
-          ],
-          "return": "real"
-        },
-        {
-          "args": [
-            {
-              "name": "x",
-              "type": "real[]"
             }
           ],
           "return": "real"
@@ -6247,6 +8772,37 @@
       "math": false,
       "operator": false,
       "sampling": "logistic",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "logistic_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -6441,6 +8997,37 @@
         }
       ]
     },
+    "lognormal_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "lognormal_rng": {
       "density": false,
       "deprecated": false,
@@ -6468,6 +9055,24 @@
         }
       ]
     },
+    "machine_precision": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
+        }
+      ]
+    },
     "map_rect": {
       "density": false,
       "deprecated": false,
@@ -6492,15 +9097,15 @@
             },
             {
               "name": "theta",
-              "type": "vector[]"
+              "type": "array[] vector"
             },
             {
               "name": "x_r",
-              "type": "data real[,]"
+              "type": "data array[,] real"
             },
             {
               "name": "x_i",
-              "type": "data int[,]"
+              "type": "data array[,] int"
             }
           ],
           "return": "vector"
@@ -6600,6 +9205,24 @@
           "args": [
             {
               "name": "x",
+              "type": "array[] int"
+            }
+          ],
+          "return": "int"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "array[] real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "int"
             },
             {
@@ -6613,25 +9236,7 @@
           "args": [
             {
               "name": "x",
-              "type": "int[]"
-            }
-          ],
-          "return": "int"
-        },
-        {
-          "args": [
-            {
-              "name": "x",
               "type": "matrix"
-            }
-          ],
-          "return": "real"
-        },
-        {
-          "args": [
-            {
-              "name": "x",
-              "type": "real[]"
             }
           ],
           "return": "real"
@@ -6832,7 +9437,7 @@
           "args": [
             {
               "name": "x",
-              "type": "matrix"
+              "type": "array[] real"
             }
           ],
           "return": "real"
@@ -6841,7 +9446,7 @@
           "args": [
             {
               "name": "x",
-              "type": "real[]"
+              "type": "matrix"
             }
           ],
           "return": "real"
@@ -6882,6 +9487,24 @@
           "args": [
             {
               "name": "x",
+              "type": "array[] int"
+            }
+          ],
+          "return": "int"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "array[] real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "int"
             },
             {
@@ -6895,25 +9518,7 @@
           "args": [
             {
               "name": "x",
-              "type": "int[]"
-            }
-          ],
-          "return": "int"
-        },
-        {
-          "args": [
-            {
-              "name": "x",
               "type": "matrix"
-            }
-          ],
-          "return": "real"
-        },
-        {
-          "args": [
-            {
-              "name": "x",
-              "type": "real[]"
             }
           ],
           "return": "real"
@@ -6953,6 +9558,19 @@
         {
           "args": [
             {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
               "name": "v",
               "type": "int"
             },
@@ -6980,6 +9598,19 @@
         {
           "args": [
             {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
               "name": "v",
               "type": "int"
             },
@@ -7003,6 +9634,37 @@
       "math": false,
       "operator": false,
       "sampling": "multi_gp_cholesky",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "matrix"
+            },
+            {
+              "name": "L",
+              "type": "matrix"
+            },
+            {
+              "name": "w",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "multi_gp_cholesky_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -7054,6 +9716,37 @@
         }
       ]
     },
+    "multi_gp_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "matrix"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            },
+            {
+              "name": "w",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "multi_normal_cholesky_lpdf": {
       "density": true,
       "deprecated": false,
@@ -7065,6 +9758,88 @@
       "math": false,
       "operator": false,
       "sampling": "multi_normal_cholesky",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "row_vectors"
+            },
+            {
+              "name": "mu",
+              "type": "row_vectors"
+            },
+            {
+              "name": "L",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "row_vectors"
+            },
+            {
+              "name": "mu",
+              "type": "vectors"
+            },
+            {
+              "name": "L",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vectors"
+            },
+            {
+              "name": "mu",
+              "type": "row_vectors"
+            },
+            {
+              "name": "L",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vectors"
+            },
+            {
+              "name": "mu",
+              "type": "vectors"
+            },
+            {
+              "name": "L",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "multi_normal_cholesky_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -7284,6 +10059,88 @@
         }
       ]
     },
+    "multi_normal_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "row_vectors"
+            },
+            {
+              "name": "mu",
+              "type": "row_vectors"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "row_vectors"
+            },
+            {
+              "name": "mu",
+              "type": "vectors"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vectors"
+            },
+            {
+              "name": "mu",
+              "type": "row_vectors"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vectors"
+            },
+            {
+              "name": "mu",
+              "type": "vectors"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "multi_normal_prec_lpdf": {
       "density": true,
       "deprecated": false,
@@ -7295,6 +10152,88 @@
       "math": false,
       "operator": false,
       "sampling": "multi_normal_prec",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "row_vectors"
+            },
+            {
+              "name": "mu",
+              "type": "row_vectors"
+            },
+            {
+              "name": "Omega",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "row_vectors"
+            },
+            {
+              "name": "mu",
+              "type": "vectors"
+            },
+            {
+              "name": "Omega",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vectors"
+            },
+            {
+              "name": "mu",
+              "type": "row_vectors"
+            },
+            {
+              "name": "Omega",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vectors"
+            },
+            {
+              "name": "mu",
+              "type": "vectors"
+            },
+            {
+              "name": "Omega",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "multi_normal_prec_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -7530,6 +10469,104 @@
         }
       ]
     },
+    "multi_student_t_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "row_vectors"
+            },
+            {
+              "name": "nu",
+              "type": "real"
+            },
+            {
+              "name": "mu",
+              "type": "row_vectors"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "row_vectors"
+            },
+            {
+              "name": "nu",
+              "type": "real"
+            },
+            {
+              "name": "mu",
+              "type": "vectors"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vectors"
+            },
+            {
+              "name": "nu",
+              "type": "real"
+            },
+            {
+              "name": "mu",
+              "type": "row_vectors"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vectors"
+            },
+            {
+              "name": "nu",
+              "type": "real"
+            },
+            {
+              "name": "mu",
+              "type": "vectors"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "multi_student_t_rng": {
       "density": false,
       "deprecated": false,
@@ -7628,7 +10665,34 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
+            },
+            {
+              "name": "theta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "multinomial_logit_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
             },
             {
               "name": "theta",
@@ -7662,7 +10726,7 @@
               "type": "int"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         }
       ]
     },
@@ -7682,7 +10746,34 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
+            },
+            {
+              "name": "theta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "multinomial_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
             },
             {
               "name": "theta",
@@ -7716,7 +10807,7 @@
               "type": "int"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         }
       ]
     },
@@ -7732,6 +10823,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -7879,6 +10983,106 @@
           "args": [
             {
               "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "phi",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "phi",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "phi",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "phi",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
               "type": "int"
             },
             {
@@ -7924,12 +11128,26 @@
             }
           ],
           "return": "real"
-        },
+        }
+      ]
+    },
+    "neg_binomial_2_log_glm_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
         {
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -7954,7 +11172,7 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -7979,7 +11197,7 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -8004,11 +11222,61 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
               "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "phi",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "phi",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
             },
             {
               "name": "alpha",
@@ -8038,6 +11306,37 @@
       "math": false,
       "operator": false,
       "sampling": "neg_binomial_2_log",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "eta",
+              "type": "reals"
+            },
+            {
+              "name": "phi",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "neg_binomial_2_log_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -8096,6 +11395,37 @@
       "math": false,
       "operator": false,
       "sampling": "neg_binomial_2",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "phi",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "neg_binomial_2_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -8267,6 +11597,37 @@
         }
       ]
     },
+    "neg_binomial_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "neg_binomial_rng": {
       "density": false,
       "deprecated": false,
@@ -8291,6 +11652,47 @@
             }
           ],
           "return": "R"
+        }
+      ]
+    },
+    "negative_infinity": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
+        }
+      ]
+    },
+    "norm": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "real"
         }
       ]
     },
@@ -8336,6 +11738,170 @@
       "math": false,
       "operator": false,
       "sampling": "normal_id_glm",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "real"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "sigma",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "real"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "sigma",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vector"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "sigma",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vector"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "sigma",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vector"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "sigma",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "vector"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "sigma",
+              "type": "real"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "normal_id_glm_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -8582,6 +12148,37 @@
         }
       ]
     },
+    "normal_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "normal_rng": {
       "density": false,
       "deprecated": false,
@@ -8609,6 +12206,24 @@
         }
       ]
     },
+    "not_a_number": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
+        }
+      ]
+    },
     "num_elements": {
       "density": false,
       "deprecated": false,
@@ -8625,7 +12240,7 @@
           "args": [
             {
               "name": "x",
-              "type": "T[]"
+              "type": "array[] T"
             }
           ],
           "return": "int"
@@ -8656,6 +12271,649 @@
             }
           ],
           "return": "int"
+        }
+      ]
+    },
+    "ode_adams": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "ode_adams_tol": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "rel_tol",
+              "type": "data real"
+            },
+            {
+              "name": "abs_tol",
+              "type": "data real"
+            },
+            {
+              "name": "max_num_steps",
+              "type": "int"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "ode_adjoint_tol_ctl": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "rel_tol_forward",
+              "type": "data real"
+            },
+            {
+              "name": "abs_tol_forward",
+              "type": "data vector"
+            },
+            {
+              "name": "rel_tol_backward",
+              "type": "data real"
+            },
+            {
+              "name": "abs_tol_backward",
+              "type": "data vector"
+            },
+            {
+              "name": "rel_tol_quadrature",
+              "type": "data real"
+            },
+            {
+              "name": "abs_tol_qudrature",
+              "type": "data real"
+            },
+            {
+              "name": "max_num_steps",
+              "type": "int"
+            },
+            {
+              "name": "num_steps_between_checkpoints",
+              "type": "int"
+            },
+            {
+              "name": "interpolation_polynomial",
+              "type": "int"
+            },
+            {
+              "name": "solver_forward",
+              "type": "int"
+            },
+            {
+              "name": "solver_backward",
+              "type": "int"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "ode_bdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "ode_bdf_tol": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "rel_tol",
+              "type": "data real"
+            },
+            {
+              "name": "abs_tol",
+              "type": "data real"
+            },
+            {
+              "name": "max_num_steps",
+              "type": "int"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "ode_ckrk": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "ode_ckrk_tol": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "rel_tol",
+              "type": "data real"
+            },
+            {
+              "name": "abs_tol",
+              "type": "data real"
+            },
+            {
+              "name": "max_num_steps",
+              "type": "int"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "ode_rk45": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "ode_rk45_tol": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "ode",
+              "type": "function"
+            },
+            {
+              "name": "initial_state",
+              "type": "vector"
+            },
+            {
+              "name": "initial_time",
+              "type": "real"
+            },
+            {
+              "name": "times",
+              "type": "array[] real"
+            },
+            {
+              "name": "rel_tol",
+              "type": "data real"
+            },
+            {
+              "name": "abs_tol",
+              "type": "data real"
+            },
+            {
+              "name": "max_num_steps",
+              "type": "int"
+            },
+            {
+              "name": "...",
+              "type": "..."
+            }
+          ],
+          "return": "array[] vector"
+        }
+      ]
+    },
+    "one_hot_array": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "k",
+              "type": "int"
+            }
+          ],
+          "return": "array[] real"
+        }
+      ]
+    },
+    "one_hot_int_array": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "k",
+              "type": "int"
+            }
+          ],
+          "return": "array[] int"
+        }
+      ]
+    },
+    "one_hot_row_vector": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "k",
+              "type": "int"
+            }
+          ],
+          "return": "row_vector"
+        }
+      ]
+    },
+    "one_hot_vector": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "K",
+              "type": "int"
+            },
+            {
+              "name": "k",
+              "type": "int"
+            }
+          ],
+          "return": "vector"
+        }
+      ]
+    },
+    "ones_array": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "array[] real"
+        }
+      ]
+    },
+    "ones_int_array": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "array[] int"
+        }
+      ]
+    },
+    "ones_row_vector": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "row_vector"
+        }
+      ]
+    },
+    "ones_vector": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "vector"
         }
       ]
     },
@@ -8707,6 +12965,19 @@
           "args": [
             {
               "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "int"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "int"
             },
             {
@@ -8732,6 +13003,33 @@
       ]
     },
     "operator%": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": true,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "int"
+            },
+            {
+              "name": "y",
+              "type": "int"
+            }
+          ],
+          "return": "int"
+        }
+      ]
+    },
+    "operator%/%": {
       "density": false,
       "deprecated": false,
       "keyword": false,
@@ -8851,6 +13149,19 @@
       "operator": true,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        },
         {
           "args": [
             {
@@ -9038,6 +13349,19 @@
           "args": [
             {
               "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "void"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "int"
             },
             {
@@ -9139,6 +13463,28 @@
       "operator": true,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        },
         {
           "args": [
             {
@@ -9318,6 +13664,19 @@
           "args": [
             {
               "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "void"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "int"
             },
             {
@@ -9432,6 +13791,28 @@
       "operator": true,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        },
         {
           "args": [
             {
@@ -9634,6 +14015,19 @@
       "operator": true,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "void"
+        },
         {
           "args": [
             {
@@ -10216,6 +14610,19 @@
           "args": [
             {
               "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "int"
             },
             {
@@ -10317,6 +14724,19 @@
       "operator": true,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "void"
+        },
         {
           "args": [
             {
@@ -10464,6 +14884,33 @@
         }
       ]
     },
+    "operator=": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": true,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "void"
+        }
+      ]
+    },
     "operator==": {
       "density": false,
       "deprecated": false,
@@ -10476,6 +14923,19 @@
       "operator": true,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "int"
+        },
         {
           "args": [
             {
@@ -10640,6 +15100,19 @@
           "args": [
             {
               "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
               "type": "real"
             },
             {
@@ -10707,6 +15180,48 @@
           "args": [
             {
               "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "c",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "c",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
               "type": "int"
             },
             {
@@ -10744,12 +15259,26 @@
             }
           ],
           "return": "real"
-        },
+        }
+      ]
+    },
+    "ordered_logistic_glm_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
         {
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -10770,7 +15299,49 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "c",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            },
+            {
+              "name": "c",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
             },
             {
               "name": "x",
@@ -10800,6 +15371,37 @@
       "math": false,
       "operator": false,
       "sampling": "ordered_logistic",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "k",
+              "type": "ints"
+            },
+            {
+              "name": "eta",
+              "type": "vector"
+            },
+            {
+              "name": "c",
+              "type": "vectors"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "ordered_logistic_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -10878,6 +15480,37 @@
         }
       ]
     },
+    "ordered_probit_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "k",
+              "type": "ints"
+            },
+            {
+              "name": "eta",
+              "type": "vector"
+            },
+            {
+              "name": "c",
+              "type": "vectors"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "ordered_probit_rng": {
       "density": false,
       "deprecated": false,
@@ -10917,6 +15550,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -11036,6 +15682,37 @@
       "math": false,
       "operator": false,
       "sampling": "pareto",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "y_min",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "pareto_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -11223,6 +15900,41 @@
         }
       ]
     },
+    "pareto_type_2_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "lambda",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "pareto_type_2_rng": {
       "density": false,
       "deprecated": false,
@@ -11251,6 +15963,24 @@
             }
           ],
           "return": "R"
+        }
+      ]
+    },
+    "pi": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
         }
       ]
     },
@@ -11351,6 +16081,90 @@
           "args": [
             {
               "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "array[] int"
+            },
+            {
+              "name": "x",
+              "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
               "type": "int"
             },
             {
@@ -11388,12 +16202,26 @@
             }
           ],
           "return": "real"
-        },
+        }
+      ]
+    },
+    "poisson_log_glm_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
         {
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -11414,7 +16242,7 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -11435,7 +16263,7 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
@@ -11456,11 +16284,53 @@
           "args": [
             {
               "name": "y",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "x",
               "type": "row_vector"
+            },
+            {
+              "name": "alpha",
+              "type": "vector"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
+            },
+            {
+              "name": "alpha",
+              "type": "real"
+            },
+            {
+              "name": "beta",
+              "type": "vector"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "int"
+            },
+            {
+              "name": "x",
+              "type": "matrix"
             },
             {
               "name": "alpha",
@@ -11486,6 +16356,33 @@
       "math": false,
       "operator": false,
       "sampling": "poisson_log",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "poisson_log_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -11552,6 +16449,33 @@
         }
       ]
     },
+    "poisson_lupmf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "ints"
+            },
+            {
+              "name": "lambda",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "poisson_rng": {
       "density": false,
       "deprecated": false,
@@ -11575,6 +16499,51 @@
         }
       ]
     },
+    "polar": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "r",
+              "type": "real"
+            },
+            {
+              "name": "theta",
+              "type": "real"
+            }
+          ],
+          "return": "complex"
+        }
+      ]
+    },
+    "positive_infinity": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
+        }
+      ]
+    },
     "pow": {
       "density": false,
       "deprecated": false,
@@ -11587,6 +16556,32 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            },
+            {
+              "name": "y",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        },
         {
           "args": [
             {
@@ -11649,7 +16644,16 @@
           "args": [
             {
               "name": "x",
-              "type": "int[]"
+              "type": "array[] int"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "array[] real"
             }
           ],
           "return": "real"
@@ -11659,15 +16663,6 @@
             {
               "name": "x",
               "type": "matrix"
-            }
-          ],
-          "return": "real"
-        },
-        {
-          "args": [
-            {
-              "name": "x",
-              "type": "real[]"
             }
           ],
           "return": "real"
@@ -11689,6 +16684,29 @@
             }
           ],
           "return": "real"
+        }
+      ]
+    },
+    "proj": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -11904,6 +16922,98 @@
         }
       ]
     },
+    "quantile": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "data array[] real"
+            },
+            {
+              "name": "p",
+              "type": "data array[] real"
+            }
+          ],
+          "return": "array[] real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "data array[] real"
+            },
+            {
+              "name": "p",
+              "type": "data real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "data row_vector"
+            },
+            {
+              "name": "p",
+              "type": "data array[] real"
+            }
+          ],
+          "return": "array[] real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "data row_vector"
+            },
+            {
+              "name": "p",
+              "type": "data real"
+            }
+          ],
+          "return": "real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "data vector"
+            },
+            {
+              "name": "p",
+              "type": "data array[] real"
+            }
+          ],
+          "return": "array[] real"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "data vector"
+            },
+            {
+              "name": "p",
+              "type": "data real"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "rank": {
       "density": false,
       "deprecated": false,
@@ -11920,7 +17030,7 @@
           "args": [
             {
               "name": "v",
-              "type": "int[]"
+              "type": "array[] int"
             },
             {
               "name": "s",
@@ -11933,7 +17043,7 @@
           "args": [
             {
               "name": "v",
-              "type": "real[]"
+              "type": "array[] real"
             },
             {
               "name": "s",
@@ -12078,6 +17188,33 @@
         }
       ]
     },
+    "rayleigh_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "rayleigh_rng": {
       "density": false,
       "deprecated": false,
@@ -12121,7 +17258,7 @@
             },
             {
               "name": "x",
-              "type": "T[]"
+              "type": "array[] T"
             },
             {
               "name": "grainsize",
@@ -12206,7 +17343,7 @@
               "type": "int"
             }
           ],
-          "return": "T[,,]"
+          "return": "array[,,] T"
         },
         {
           "args": [
@@ -12223,7 +17360,7 @@
               "type": "int"
             }
           ],
-          "return": "T[,]"
+          "return": "array[,] T"
         },
         {
           "args": [
@@ -12236,7 +17373,7 @@
               "type": "int"
             }
           ],
-          "return": "T[]"
+          "return": "array[] T"
         }
       ]
     },
@@ -12367,10 +17504,10 @@
           "args": [
             {
               "name": "v",
-              "type": "T[]"
+              "type": "array[] T"
             }
           ],
-          "return": "T[]"
+          "return": "array[] T"
         },
         {
           "args": [
@@ -12404,6 +17541,19 @@
       "operator": false,
       "sampling": null,
       "signatures": [
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "T1"
+            },
+            {
+              "name": "y",
+              "type": "T2"
+            }
+          ],
+          "return": "R"
+        },
         {
           "args": [
             {
@@ -12759,6 +17909,37 @@
         }
       ]
     },
+    "scaled_inv_chi_square_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "nu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "scaled_inv_chi_square_rng": {
       "density": false,
       "deprecated": false,
@@ -12802,7 +17983,7 @@
           "args": [
             {
               "name": "x",
-              "type": "matrix"
+              "type": "array[] real"
             }
           ],
           "return": "real"
@@ -12811,7 +17992,7 @@
           "args": [
             {
               "name": "x",
-              "type": "real[]"
+              "type": "matrix"
             }
           ],
           "return": "real"
@@ -12852,7 +18033,7 @@
           "args": [
             {
               "name": "sv",
-              "type": "T[]"
+              "type": "array[] T"
             },
             {
               "name": "i",
@@ -12863,7 +18044,7 @@
               "type": "int"
             }
           ],
-          "return": "T[]"
+          "return": "array[] T"
         },
         {
           "args": [
@@ -12921,6 +18102,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -12967,6 +18157,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -12986,10 +18185,257 @@
           "args": [
             {
               "name": "x",
-              "type": "T[]"
+              "type": "array[] T"
             }
           ],
           "return": "int"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "int"
+            }
+          ],
+          "return": "int"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "matrix"
+            }
+          ],
+          "return": "int"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "real"
+            }
+          ],
+          "return": "int"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "row_vector"
+            }
+          ],
+          "return": "int"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "vector"
+            }
+          ],
+          "return": "int"
+        }
+      ]
+    },
+    "skew_double_exponential_cdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            },
+            {
+              "name": "tau",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "skew_double_exponential_lccdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": true,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": false,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            },
+            {
+              "name": "tau",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "skew_double_exponential_lcdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": true,
+      "lpdf": false,
+      "lpmf": false,
+      "math": false,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            },
+            {
+              "name": "tau",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "skew_double_exponential_lpdf": {
+      "density": true,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": true,
+      "lpmf": false,
+      "math": false,
+      "operator": false,
+      "sampling": "skew_double_exponential",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            },
+            {
+              "name": "tau",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "skew_double_exponential_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            },
+            {
+              "name": "tau",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "skew_double_exponential_rng": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "R"
         }
       ]
     },
@@ -13133,6 +18579,41 @@
         }
       ]
     },
+    "skew_normal_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "xi",
+              "type": "reals"
+            },
+            {
+              "name": "omega",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "skew_normal_rng": {
       "density": false,
       "deprecated": false,
@@ -13203,19 +18684,19 @@
           "args": [
             {
               "name": "v",
-              "type": "int[]"
+              "type": "array[] int"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         },
         {
           "args": [
             {
               "name": "v",
-              "type": "real[]"
+              "type": "array[] real"
             }
           ],
-          "return": "real[]"
+          "return": "array[] real"
         },
         {
           "args": [
@@ -13253,19 +18734,19 @@
           "args": [
             {
               "name": "v",
-              "type": "int[]"
+              "type": "array[] int"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         },
         {
           "args": [
             {
               "name": "v",
-              "type": "real[]"
+              "type": "array[] real"
             }
           ],
-          "return": "real[]"
+          "return": "array[] real"
         },
         {
           "args": [
@@ -13303,19 +18784,19 @@
           "args": [
             {
               "name": "v",
-              "type": "int[]"
+              "type": "array[] int"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         },
         {
           "args": [
             {
               "name": "v",
-              "type": "real[]"
+              "type": "array[] real"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         },
         {
           "args": [
@@ -13324,7 +18805,7 @@
               "type": "row_vector"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         },
         {
           "args": [
@@ -13333,7 +18814,7 @@
               "type": "vector"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         }
       ]
     },
@@ -13353,19 +18834,19 @@
           "args": [
             {
               "name": "v",
-              "type": "int[]"
+              "type": "array[] int"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         },
         {
           "args": [
             {
               "name": "v",
-              "type": "real[]"
+              "type": "array[] real"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         },
         {
           "args": [
@@ -13374,7 +18855,7 @@
               "type": "row_vector"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         },
         {
           "args": [
@@ -13383,7 +18864,7 @@
               "type": "vector"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
         }
       ]
     },
@@ -13407,6 +18888,33 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "x",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        }
+      ]
+    },
+    "sqrt2": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
         }
       ]
     },
@@ -13453,7 +18961,7 @@
             },
             {
               "name": "y",
-              "type": "row_vector[]"
+              "type": "row_vector"
             }
           ],
           "return": "real"
@@ -13466,7 +18974,7 @@
             },
             {
               "name": "y",
-              "type": "vector[]"
+              "type": "vector"
             }
           ],
           "return": "real"
@@ -13479,7 +18987,7 @@
             },
             {
               "name": "y",
-              "type": "row_vector[]"
+              "type": "row_vector"
             }
           ],
           "return": "real"
@@ -13579,6 +19087,29 @@
       "math": false,
       "operator": false,
       "sampling": "std_normal",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "std_normal_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -13772,6 +19303,41 @@
         }
       ]
     },
+    "student_t_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "nu",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "student_t_rng": {
       "density": false,
       "deprecated": false,
@@ -13889,7 +19455,7 @@
           "args": [
             {
               "name": "x",
-              "type": "int[]"
+              "type": "array[] int"
             }
           ],
           "return": "int"
@@ -13898,7 +19464,7 @@
           "args": [
             {
               "name": "x",
-              "type": "matrix"
+              "type": "array[] real"
             }
           ],
           "return": "real"
@@ -13907,7 +19473,7 @@
           "args": [
             {
               "name": "x",
-              "type": "real[]"
+              "type": "matrix"
             }
           ],
           "return": "real"
@@ -13932,6 +19498,75 @@
         }
       ]
     },
+    "svd_U": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "A",
+              "type": "matrix"
+            }
+          ],
+          "return": "vector"
+        }
+      ]
+    },
+    "svd_V": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "A",
+              "type": "matrix"
+            }
+          ],
+          "return": "vector"
+        }
+      ]
+    },
+    "symmetrize_from_lower_tri": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "A",
+              "type": "matrix"
+            }
+          ],
+          "return": "matrix"
+        }
+      ]
+    },
     "tail": {
       "density": false,
       "deprecated": false,
@@ -13948,14 +19583,14 @@
           "args": [
             {
               "name": "sv",
-              "type": "T[]"
+              "type": "array[] T"
             },
             {
               "name": "n",
               "type": "int"
             }
           ],
-          "return": "T[]"
+          "return": "array[] T"
         },
         {
           "args": [
@@ -14005,6 +19640,15 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -14028,6 +19672,33 @@
             }
           ],
           "return": "R"
+        },
+        {
+          "args": [
+            {
+              "name": "z",
+              "type": "complex"
+            }
+          ],
+          "return": "complex"
+        }
+      ]
+    },
+    "target": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "real"
         }
       ]
     },
@@ -14093,10 +19764,19 @@
           "args": [
             {
               "name": "a",
-              "type": "int[...]"
+              "type": "array[...] int"
             }
           ],
-          "return": "int[]"
+          "return": "array[] int"
+        },
+        {
+          "args": [
+            {
+              "name": "a",
+              "type": "array[...] real"
+            }
+          ],
+          "return": "array[] real"
         },
         {
           "args": [
@@ -14105,16 +19785,7 @@
               "type": "matrix"
             }
           ],
-          "return": "real[]"
-        },
-        {
-          "args": [
-            {
-              "name": "a",
-              "type": "real[...]"
-            }
-          ],
-          "return": "real[]"
+          "return": "array[] real"
         },
         {
           "args": [
@@ -14123,7 +19794,7 @@
               "type": "row_vector"
             }
           ],
-          "return": "real[]"
+          "return": "array[] real"
         },
         {
           "args": [
@@ -14132,7 +19803,7 @@
               "type": "vector"
             }
           ],
-          "return": "real[]"
+          "return": "array[] real"
         }
       ]
     },
@@ -14155,7 +19826,47 @@
               "type": "matrix"
             }
           ],
-          "return": "real[,]"
+          "return": "array[,] real"
+        }
+      ]
+    },
+    "to_complex": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [],
+          "return": "complex"
+        },
+        {
+          "args": [
+            {
+              "name": "re",
+              "type": "real"
+            }
+          ],
+          "return": "complex"
+        },
+        {
+          "args": [
+            {
+              "name": "re",
+              "type": "real"
+            },
+            {
+              "name": "im",
+              "type": "real"
+            }
+          ],
+          "return": "complex"
         }
       ]
     },
@@ -14175,7 +19886,7 @@
           "args": [
             {
               "name": "a",
-              "type": "int[,]"
+              "type": "array[,] int"
             }
           ],
           "return": "matrix"
@@ -14184,7 +19895,16 @@
           "args": [
             {
               "name": "a",
-              "type": "int[]"
+              "type": "array[,] real"
+            }
+          ],
+          "return": "matrix"
+        },
+        {
+          "args": [
+            {
+              "name": "a",
+              "type": "array[] int"
             },
             {
               "name": "m",
@@ -14201,7 +19921,45 @@
           "args": [
             {
               "name": "a",
-              "type": "int[]"
+              "type": "array[] int"
+            },
+            {
+              "name": "m",
+              "type": "int"
+            },
+            {
+              "name": "n",
+              "type": "int"
+            },
+            {
+              "name": "col_major",
+              "type": "int"
+            }
+          ],
+          "return": "matrix"
+        },
+        {
+          "args": [
+            {
+              "name": "a",
+              "type": "array[] real"
+            },
+            {
+              "name": "m",
+              "type": "int"
+            },
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "matrix"
+        },
+        {
+          "args": [
+            {
+              "name": "a",
+              "type": "array[] real"
             },
             {
               "name": "m",
@@ -14249,53 +20007,6 @@
             {
               "name": "m",
               "type": "matrix"
-            },
-            {
-              "name": "m",
-              "type": "int"
-            },
-            {
-              "name": "n",
-              "type": "int"
-            },
-            {
-              "name": "col_major",
-              "type": "int"
-            }
-          ],
-          "return": "matrix"
-        },
-        {
-          "args": [
-            {
-              "name": "a",
-              "type": "real[,]"
-            }
-          ],
-          "return": "matrix"
-        },
-        {
-          "args": [
-            {
-              "name": "a",
-              "type": "real[]"
-            },
-            {
-              "name": "m",
-              "type": "int"
-            },
-            {
-              "name": "n",
-              "type": "int"
-            }
-          ],
-          "return": "matrix"
-        },
-        {
-          "args": [
-            {
-              "name": "a",
-              "type": "real[]"
             },
             {
               "name": "m",
@@ -14424,7 +20135,16 @@
           "args": [
             {
               "name": "a",
-              "type": "int[]"
+              "type": "array[] int"
+            }
+          ],
+          "return": "row_vector"
+        },
+        {
+          "args": [
+            {
+              "name": "a",
+              "type": "array[] real"
             }
           ],
           "return": "row_vector"
@@ -14434,15 +20154,6 @@
             {
               "name": "m",
               "type": "matrix"
-            }
-          ],
-          "return": "row_vector"
-        },
-        {
-          "args": [
-            {
-              "name": "a",
-              "type": "real[]"
             }
           ],
           "return": "row_vector"
@@ -14483,7 +20194,16 @@
           "args": [
             {
               "name": "a",
-              "type": "int[]"
+              "type": "array[] int"
+            }
+          ],
+          "return": "vector"
+        },
+        {
+          "args": [
+            {
+              "name": "a",
+              "type": "array[] real"
             }
           ],
           "return": "vector"
@@ -14493,15 +20213,6 @@
             {
               "name": "m",
               "type": "matrix"
-            }
-          ],
-          "return": "vector"
-        },
-        {
-          "args": [
-            {
-              "name": "a",
-              "type": "real[]"
             }
           ],
           "return": "vector"
@@ -14777,6 +20488,37 @@
         }
       ]
     },
+    "uniform_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "uniform_rng": {
       "density": false,
       "deprecated": false,
@@ -14804,6 +20546,29 @@
         }
       ]
     },
+    "uniform_simplex": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "vector"
+        }
+      ]
+    },
     "variance": {
       "density": false,
       "deprecated": false,
@@ -14820,7 +20585,7 @@
           "args": [
             {
               "name": "x",
-              "type": "matrix"
+              "type": "array[] real"
             }
           ],
           "return": "real"
@@ -14829,7 +20594,7 @@
           "args": [
             {
               "name": "x",
-              "type": "real[]"
+              "type": "matrix"
             }
           ],
           "return": "real"
@@ -14865,6 +20630,37 @@
       "math": false,
       "operator": false,
       "sampling": "von_mises",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "mu",
+              "type": "reals"
+            },
+            {
+              "name": "kappa",
+              "type": "reals"
+            }
+          ],
+          "return": "R"
+        }
+      ]
+    },
+    "von_mises_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -15036,6 +20832,37 @@
         }
       ]
     },
+    "weibull_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "sigma",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "weibull_rng": {
       "density": false,
       "deprecated": false,
@@ -15102,6 +20929,45 @@
         }
       ]
     },
+    "wiener_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "y",
+              "type": "reals"
+            },
+            {
+              "name": "alpha",
+              "type": "reals"
+            },
+            {
+              "name": "tau",
+              "type": "reals"
+            },
+            {
+              "name": "beta",
+              "type": "reals"
+            },
+            {
+              "name": "delta",
+              "type": "reals"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
     "wishart_lpdf": {
       "density": true,
       "deprecated": false,
@@ -15113,6 +20979,37 @@
       "math": false,
       "operator": false,
       "sampling": "wishart",
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "W",
+              "type": "matrix"
+            },
+            {
+              "name": "nu",
+              "type": "real"
+            },
+            {
+              "name": "Sigma",
+              "type": "matrix"
+            }
+          ],
+          "return": "real"
+        }
+      ]
+    },
+    "wishart_lupdf": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
       "signatures": [
         {
           "args": [
@@ -15159,6 +21056,84 @@
           "return": "matrix"
         }
       ]
+    },
+    "zeros_array": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "array[] real"
+        }
+      ]
+    },
+    "zeros_int_array": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "array[] int"
+        }
+      ]
+    },
+    "zeros_row_vector": {
+      "density": false,
+      "deprecated": false,
+      "keyword": false,
+      "lccdf": false,
+      "lcdf": false,
+      "lpdf": false,
+      "lpmf": false,
+      "math": true,
+      "operator": false,
+      "sampling": null,
+      "signatures": [
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "row_vector"
+        },
+        {
+          "args": [
+            {
+              "name": "n",
+              "type": "int"
+            }
+          ],
+          "return": "vector"
+        }
+      ]
     }
   },
   "keywords": {
@@ -15180,13 +21155,13 @@
     ],
     "other": [
       "return",
-      "target",
-      "offset",
-      "multiplier"
+      "target"
     ],
     "range_constraints": [
       "lower",
-      "upper"
+      "upper",
+      "offset",
+      "multiplier"
     ]
   },
   "operators": [
@@ -15204,6 +21179,8 @@
     "/",
     "%",
     "\\",
+    ".^",
+    "%/%",
     ".*",
     "./",
     "!",
@@ -15311,6 +21288,12 @@
       "else",
       "true",
       "false",
+      "print",
+      "reject",
+      "profile",
+      "get_lp",
+      "increment_log_prob",
+      "target",
       "var",
       "fvar",
       "STAN_MAJOR",
@@ -15333,6 +21316,7 @@
     "return": [
       "int",
       "real",
+      "complex",
       "vector",
       "row_vector",
       "matrix",
@@ -15341,6 +21325,7 @@
     "variable": [
       "int",
       "real",
+      "complex",
       "matrix",
       "cov_matrix",
       "corr_matrix",
@@ -15354,5 +21339,5 @@
       "row_vector"
     ]
   },
-  "version": "2.24"
+  "version": "2.28"
 }

--- a/stan_lang.json
+++ b/stan_lang.json
@@ -21309,6 +21309,7 @@
     "basic": [
       "int",
       "real",
+      "complex",
       "vector",
       "row_vector",
       "matrix"


### PR DESCRIPTION
- Update functions to latest and parse new `array [] int` syntax as replacement for `int[]` syntax
- Add `.^` and `%/%` operators
- Add support for the `complex` type